### PR TITLE
Correct mislabeled examples from presentation_definition to presentation_submission

### DIFF
--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -1487,7 +1487,7 @@ This example is identic to the previous one with the following exceptions: It se
 
 A non-normative example of the Authorization Response would look the same as in the examples of other Credential formats. It would contain the `presentation_submission` and `vp_token` parameters.
 
-The following is a non-normative example of the content of the `presentation_definition` parameter:
+The following is a non-normative example of the content of the `presentation_submission` parameter:
 
 <{{examples/response/ps_ac_vc_sd.json}}
 
@@ -1527,7 +1527,7 @@ Setting `limit_disclosure` property defined in [@!DIF.PresentationExchange] to `
 
 A non-normative example of the Authorization Response would look the same as in the examples of other Credential formats in this Annex.
 
-The following is a non-normative example of the content of the `presentation_definition` parameter:
+The following is a non-normative example of the content of the `presentation_submission` parameter:
 
 <{{examples/response/ps_mdl_iso_cbor.json}}
 


### PR DESCRIPTION
While reading parts of OpenID4VP, I came across what I believe to be a cut-and-paste error where descriptions of responses talk about a `presentation_definition` value, where I think it's actually a `presentation_submission` value.  What tipped me off is that `descriptor_map` fields go in `presentation_submission` objects.