### PR TITLE
Remove `client_id_scheme` from Verifier Metadata

### DIFF
--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -762,9 +762,6 @@ This specification defines the following new metadata parameters according to [@
 : REQUIRED. An object defining the formats and proof types of Verifiable Presentations and Verifiable Credentials that a Verifier supports. For specific values that can be used, see (#alternative_credential_formats).
 Deployments can extend the formats supported, provided Issuers, Holders and Verifiers all understand the new format.
 
-`client_id_scheme`:
-: OPTIONAL. JSON String identifying the Client Identifier scheme. The value range defined by this specification is `pre-registered`, `redirect_uri`, `entity_id`, `did`. If omitted, the default value is `pre-registered`. 
-
 # Verifier Attestation JWT {#verifier_attestation_jwt}
 
 The Verifier Attestation JWT is a JWT especially designed to allow a Wallet to authenticate a Verifier in a secure and flexible manner. A Verifier Attestation JWT is issued to the Verifier by a party that wallets trust for the purpose of authentication and authorization of Verifiers. The way this trust established is out of scope of this specification. Every Verifier is bound to a public key, the Verifier MUST always present a Verifier Attestation JWT along with the proof of possession for this key. In the case of the `client_id_scheme` `verifier_attestation`, the authorization request is signed with this key, which serves as proof of possession.


### PR DESCRIPTION
There is currently some ambiguity around `client_id_scheme`. This parameter appears in the request object AND the client metadata, which also appears in the request object. There is no text in the specification to define what a wallet should do if it receives a rquest object where these two values do not match.

As I see it there are 3 ways forwards:
1. Remove `client_id_scheme` from Verifier Metadata.
2. Remove `client_id_scheme` from the authz request object, AND make it so that either `client_metadata` or `client_metadata_uri` are always provided in the request object.
3. Add text to describe what a wallet should do if it receives a request object with mismatching `client_id_scheme`.

I have raised this PR with option 1.