### PR TITLE
redirect_uri section, added fragment and small editorials

### DIFF
--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -592,7 +592,7 @@ The following new parameter is defined for use in the response from the endpoint
 
 Note: Response Mode `direct_post` without the `redirect_uri` could be less secure than Response Modes with redirects. For details, see ((#session_fixation)).
 
-The value of the redirect URI is an absolute URI as defined by [@!RFC3986] Section 4.3 and is chosen by the Verifier. The Verifier MUST include a fresh, cryptographically random number in the URL. This number is used to ensure only the receiver of the redirect can fetch and process the Authorization Response. The number could be added as a path component or a parameter to the URL. It is RECOMMENDED to use a cryptographic random value of 128 bits or more at the time of the writing of this specification. For implementation considerations see (#implementation_considerations_direct_post).
+The value of the redirect URI is an absolute URI as defined by [@!RFC3986] Section 4.3 and is chosen by the Verifier. The Verifier MUST include a fresh, cryptographically random value in the URL. This value is used to ensure only the receiver of the redirect can fetch and process the Authorization Response. The value can be added as a path component, as a fragment or as a parameter to the URL. It is RECOMMENDED to use a cryptographic random value of 128 bits or more. For implementation considerations see (#implementation_considerations_direct_post).
 
 The following is a non-normative example of the response from the Verifier to the Wallet upon receiving the Authorization Response at the Response Endpoint (using a `response_code` parameter from (#implementation_considerations_direct_post)):
 
@@ -606,9 +606,9 @@ The following is a non-normative example of the response from the Verifier to th
   }
 ```
 
-If the response does not contain a parameter, the Wallet is not required by this specification to perform any further steps.
+If the response does not contain the `redirect_uri`, the Wallet is not required to perform any further steps.
 
-Note: In the Response Mode `direct_post` or `direct_post.jwt`, the Wallet can change the UI based on the verifier's callback to the wallet following the submission of the Authorization Response.
+Note: In the Response Mode `direct_post` or `direct_post.jwt`, the Wallet can change the UI based on the Verifier's callback to the Wallet following the submission of the Authorization Response.
 
 ## Signed and Encrypted Responses {#jarm}
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -606,7 +606,7 @@ The following is a non-normative example of the response from the Verifier to th
   }
 ```
 
-If the response does not contain the `redirect_uri`, the Wallet is not required to perform any further steps.
+If the response does not contain the `redirect_uri` parameter, the Wallet is not required to perform any further steps.
 
 Note: In the Response Mode `direct_post` or `direct_post.jwt`, the Wallet can change the UI based on the Verifier's callback to the Wallet following the submission of the Authorization Response.
 


### PR DESCRIPTION
This PR fixes some terminology and adds the fragment in the description of the response_code, since the previous text mentioned only url path and param while the non-normative examples contained a fragment

 