### PR TITLE
It's unnecessary to specify encoding for the application/json content…

### DIFF
--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -596,7 +596,7 @@ The following is a non-normative example of the response from the Verifier to th
 
 ```
   HTTP/1.1 200 OK
-  Content-Type: application/json;charset=UTF-8
+  Content-Type: application/json
   Cache-Control: no-store
 
   {


### PR DESCRIPTION
… type.