### PR TITLE
A minor correction for an example in the Verifier Metadata Management section

### DIFF
--- a/examples/request/request_object_client_id_did.json
+++ b/examples/request/request_object_client_id_did.json
@@ -1,7 +1,7 @@
 {
    "client_id": "did:example:123",
    "client_id_scheme": "did",
-   "response_types": "vp_token",
+   "response_type": "vp_token",
    "redirect_uri": "https://client.example.org/callback",
    "nonce":"n-0S6_WzA2Mj",
    "presentation_definition": "...",


### PR DESCRIPTION
This property called as `response_type`.