### PR TITLE
remove references to jwt_vp to align on jwt_vp_json

### DIFF
--- a/examples/response/id_token_is_jwt_vp.json
+++ b/examples/response/id_token_is_jwt_vp.json
@@ -78,7 +78,7 @@
     "presentation_submission": {
         "descriptor_map": [
             {
-                "format": "jwt_vp",
+                "format": "jwt_vp_json",
                 "id": "citizenship",
                 "path": "$",
                 "path_nested": {

--- a/examples/response/id_token_ref_vp_token_multple_vps.json
+++ b/examples/response/id_token_ref_vp_token_multple_vps.json
@@ -27,7 +27,7 @@
                 },
                 {
                     "id": "Ontario Health Insurance Plan",
-                    "format": "jwt_vp",
+                    "format": "jwt_vp_json",
                     "path": "$[1].presentation",
                     "path_nested": {
                         "format": "jwt_vc",

--- a/examples/response/jarm_jwt_enc_only_vc_json_body.json
+++ b/examples/response/jarm_jwt_enc_only_vc_json_body.json
@@ -7,7 +7,7 @@
             {
                 "id": "id_credential",
                 "path": "$",
-                "format": "jwt_vp",
+                "format": "jwt_vp_json",
                 "path_nested": {
                     "path": "$.vp.verifiableCredential[0]",
                     "format": "jwt_vc"

--- a/examples/response/jarm_jwt_vc_json_body.json
+++ b/examples/response/jarm_jwt_vc_json_body.json
@@ -10,7 +10,7 @@
             {
                 "id": "id_credential",
                 "path": "$",
-                "format": "jwt_vp",
+                "format": "jwt_vp_json",
                 "path_nested": {
                     "path": "$.vp.verifiableCredential[0]",
                     "format": "jwt_vc"

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -454,7 +454,7 @@ The following is a non-normative example of a request when `client_id` equals `r
     &redirect_uri=https%3A%2F%2Fclient.example.org%2Fcb
     &presentation_definition=...
     &nonce=n-0S6_WzA2Mj
-    &client_metadata=%7B%22vp_formats%22:%7B%22jwt_vp%22:%
+    &client_metadata=%7B%22vp_formats%22:%7B%22jwt_vp_json%22:%
     7B%22alg%22:%5B%22EdDSA%22,%22ES256K%22%5D%7D,%22ldp
     _vp%22:%7B%22proof_type%22:%5B%22Ed25519Signature201
     8%22%5D%7D%7D%7D


### PR DESCRIPTION
resolves issue #122 

the spec text normatively defines `jwt_vp_json`, so to avoid breaking changes, this PR changes all the mentions of `jwt_vp` to `jwt_vp_json`.