### PR TITLE
Update the text about the response returned by the browser API

### DIFF
--- a/examples/digital_credentials_api/response_value.json
+++ b/examples/digital_credentials_api/response_value.json
@@ -1,4 +1,4 @@
 {
-  "presentation_submission": "...",
+  "presentation_submission": {...},
   "vp_token": "..."
 }

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -1611,17 +1611,30 @@ The signed request allows the Wallet to authenticate the Verifier using a trust 
 
 ## Response
 
-Every OpenID4VP Authorization Request MUST result in a response being provided through the W3C Digital Credentials API. The Authorization Response is a JavaScript object, where the response parameters as defined for the Response Type are encoded as top-level members in this JavaScript object. 
+Every OpenID4VP Authorization Request MUST result in a response being provided through the W3C Digital Credentials API. The response is a JavaScript object, where the Authorization Response parameters as defined for the Response Type are encoded as members within the `data` member of this JavaScript object.
 
-The following is a non-normative example of an OpenID4VP response that could be received from the W3C Digital Credentials API:
-	
+The following is a non-normative example of an unsigned OpenID4VP response that could be received from the W3C Digital Credentials API:
+
 ```js
 {
-  vp_token: "...",
-  presentation_submission: {...}
+  protocol: "openid4vp",
+  data: {
+    vp_token: "...",
+    presentation_submission: {...}
+  }
 }
 ```
 
+The following is a non-normative example of an encrypted OpenID4VP response that could be received from the W3C Digital Credentials API:
+
+```js
+{
+  protocol: "openid4vp",
+  data: {
+    response: "eyJhbGciOiJ..."
+  }
+}
+```
 
 # Examples with Credentials in Various Formats {#alternative_credential_formats}
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -1613,27 +1613,25 @@ The signed request allows the Wallet to authenticate the Verifier using a trust 
 
 Every OpenID4VP Authorization Request MUST result in a response being provided through the W3C Digital Credentials API. This response is a JavaScript object as defined in [@!w3c.digital_credentials_api], where the OpenID4VP Authorization Response parameters as defined for the Response Type are encoded as members within the `data` member of this JavaScript object.
 
-The following is a non-normative example of an unsigned OpenID4VP response that could be received from the W3C Digital Credentials API:
+The following is a non-normative example of processing an unsigned OpenID4VP response that could be received from the W3C Digital Credentials API:
 
 ```js
-{
-  protocol: "openid4vp",
-  data: {
-    vp_token: "...",
-    presentation_submission: {...}
-  }
-}
+const credential = await navigator.identity.get(request);
+if (credential.protocol == "openid4vp") {
+  // Extract relevant data members
+  const { vp_token, presentation_submission } =  credential.data;
+  // presentation_submission is a javascript object
+  // vp_token is a string or javascript object depending on the credential type
 ```
 
-The following is a non-normative example of an encrypted OpenID4VP response that could be received from the W3C Digital Credentials API:
+The following is a non-normative example of processing an encrypted OpenID4VP response that could be received from the W3C Digital Credentials API:
 
 ```js
-{
-  protocol: "openid4vp",
-  data: {
-    response: "eyJhbGciOiJ..."
-  }
-}
+const credential = await navigator.identity.get(request);
+if (credential.protocol == "openid4vp") {
+  // Extract encrypted response
+  const { response } =  credential.data;
+  // response is a string containing a JWE, now decrypt it
 ```
 
 # Examples with Credentials in Various Formats {#alternative_credential_formats}

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -1622,6 +1622,7 @@ if (credential.protocol == "openid4vp") {
   const { vp_token, presentation_submission } =  credential.data;
   // presentation_submission is a javascript object
   // vp_token is a string or javascript object depending on the credential type
+}
 ```
 
 The following is a non-normative example of processing an encrypted OpenID4VP response that could be received from the W3C Digital Credentials API:
@@ -1632,6 +1633,7 @@ if (credential.protocol == "openid4vp") {
   // Extract encrypted response
   const { response } =  credential.data;
   // response is a string containing a JWE, now decrypt it
+}
 ```
 
 # Examples with Credentials in Various Formats {#alternative_credential_formats}

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -1611,7 +1611,7 @@ The signed request allows the Wallet to authenticate the Verifier using a trust 
 
 ## Response
 
-Every OpenID4VP Authorization Request results in a response being provided through the W3C Digital Credentials API. The response is an instance of a `DigitalCredential` credential interface, as defined in [@!w3c.digital_credentials_api], and the OpenID4VP Authorization Response parameters as defined for the Response Type are represented as an object within the `data` attribute.
+Every OpenID4VP Authorization Request results in a response being provided through the W3C Digital Credentials API. The response is an instance of the `DigitalCredential` credential interface, as defined in [@!w3c.digital_credentials_api], and the OpenID4VP Authorization Response parameters as defined for the Response Type are represented as an object within the `data` attribute.
 
 The following is a non-normative example of processing an unsigned OpenID4VP response that could be received from the W3C Digital Credentials API:
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -1611,7 +1611,7 @@ The signed request allows the Wallet to authenticate the Verifier using a trust 
 
 ## Response
 
-Every OpenID4VP Authorization Request MUST result in a response being provided through the W3C Digital Credentials API. This response is a JavaScript object as defined in [@!w3c.digital_credentials_api], where the OpenID4VP Authorization Response parameters as defined for the Response Type are encoded as members within the `data` member of this JavaScript object.
+Every OpenID4VP Authorization Request results in a response being provided through the W3C Digital Credentials API. The response is an instance of a `DigitalCredential` credential interface, as defined in [@!w3c.digital_credentials_api], and the OpenID4VP Authorization Response parameters as defined for the Response Type are represented as an object within the `data` attribute.
 
 The following is a non-normative example of processing an unsigned OpenID4VP response that could be received from the W3C Digital Credentials API:
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -1611,7 +1611,7 @@ The signed request allows the Wallet to authenticate the Verifier using a trust 
 
 ## Response
 
-Every OpenID4VP Authorization Request MUST result in a response being provided through the W3C Digital Credentials API. The response is a JavaScript object as defined in [@!w3c.digital_credentials_api], where the Authorization Response parameters as defined for the Response Type are encoded as members within the `data` member of this JavaScript object.
+Every OpenID4VP Authorization Request MUST result in a response being provided through the W3C Digital Credentials API. This response is a JavaScript object as defined in [@!w3c.digital_credentials_api], where the OpenID4VP Authorization Response parameters as defined for the Response Type are encoded as members within the `data` member of this JavaScript object.
 
 The following is a non-normative example of an unsigned OpenID4VP response that could be received from the W3C Digital Credentials API:
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -1611,7 +1611,7 @@ The signed request allows the Wallet to authenticate the Verifier using a trust 
 
 ## Response
 
-Every OpenID4VP Authorization Request MUST result in a response being provided through the W3C Digital Credentials API. The response is a JavaScript object, where the Authorization Response parameters as defined for the Response Type are encoded as members within the `data` member of this JavaScript object.
+Every OpenID4VP Authorization Request MUST result in a response being provided through the W3C Digital Credentials API. The response is a JavaScript object as defined in [@!w3c.digital_credentials_api], where the Authorization Response parameters as defined for the Response Type are encoded as members within the `data` member of this JavaScript object.
 
 The following is a non-normative example of an unsigned OpenID4VP response that could be received from the W3C Digital Credentials API:
 


### PR DESCRIPTION
This makes it consistent with the latest position from the WICG group, in particular as shown here:

https://github.com/WICG/digital-credentials/pull/141/files

i.e. the VP response is inside the 'data' member within the response object.

Also fix where presentation_submission was shown as a string in one example and add an example for an encrypted response for completeness.

closes #201