### PR TITLE
response_mode was missing in browser API example unsigned request

### DIFF
--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -1552,6 +1552,7 @@ try {
         protocol: "openid4vp",
         request:  {
           response_type: "vp_token",
+          response_mode: "is_w3c_dc_api",
           nonce: "n-0S6_WzA2Mj",
           client_metadata: {...},
           presentation_definition: {...}


### PR DESCRIPTION
Add response_mode: "is_w3c_dc_api" to browser API example unsigned request to fix #244