### PR TITLE
Fix GitHub action that publishes compiled version spec from main

### DIFF
--- a/.github/workflows/Build-OID4VP.yml
+++ b/.github/workflows/Build-OID4VP.yml
@@ -10,7 +10,7 @@ jobs:
         name: Compile site assets
         runs-on: ubuntu-latest
         steps:
-          - uses: actions/checkout@v3
+          - uses: actions/checkout@v4
           - name: Run the build process with Docker
             run: |     
                 docker run \
@@ -19,7 +19,7 @@ jobs:
           - name: rename
             run: |
                 mv ./openid-4-verifiable-presentations-1_0*.html ./openid-4-verifiable-presentations-wg-draft.html
-          - uses: actions/upload-artifact@v3
+          - uses: actions/upload-artifact@v4
             with:
                 # Artifact name
                 name: output # optional
@@ -39,13 +39,13 @@ jobs:
         url: ${{ steps.deployment.outputs.page_url }}
       steps:
         - name: Download artifact
-          uses: actions/download-artifact@v4.1.7
+          uses: actions/download-artifact@v4
           with:
             name: output
         - name: Upload pages artifact
-          uses: actions/upload-pages-artifact@v1
+          uses: actions/upload-pages-artifact@v3
           with:
             path: .
         - name: Deploy to GitHub Pages
           id: deployment
-          uses: actions/deploy-pages@v2
+          uses: actions/deploy-pages@v4


### PR DESCRIPTION
The upgrade of the download-artifact action from the version that github disabled broke other things. Upgrade various gitlab actions to latest versions to resolve this and other (non-fatal) warnings we were getting in the frontend, e.g. things like:

The following artifacts were uploaded using a version of actions/upload-artifact that is scheduled for deprecation: "github-pages".