### PR TITLE
Remove urn:ietf:params:oauth urls

### DIFF
--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -1033,8 +1033,6 @@ The following is a non-normative example of the terms of use that may be defined
 }
 ```
 
-Federations that conform to those specified in [@OpenID.Federation] are identified by the `type` `urn:ietf:params:oauth:federation`. Individual federations are identified by the Entity Identifier of the trust anchor. If the federation decides to use trust marks as signs of whether an entity belongs to a federation or not then the federation is identified by the `type` `urn:ietf:params:oauth:federation_trust_mark` and individual federations are identified by the Entity Identifier of the trust mark issuer.
-
 Trust schemes that conform to the TRAIN [@TRAIN] trust scheme are identified by the `type` `https://train.trust-scheme.de/info`. Individual federations are identified by their DNS names.
 
 The following is a non-normative example of a `claims` parameter containing a `presentation_definition` that filters VCs based on their federation memberships:


### PR DESCRIPTION
As an alternative fix to the one in:

https://github.com/openid/OpenID4VP/pull/279

Remove the paragraph that appears to create the controverial URNs.

If these URNs are needed, the federation-wallet spec:

https://github.com/peppelinux/federation-wallet

seems to be a more appropriate place to define them.