### PR TITLE
Use dcql in #browser_api_request example rather than pe 

### DIFF
--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -1987,7 +1987,7 @@ The following is a non-normative example of an unsigned OpenID4VP request (when 
   response_mode: "w3c_dc_api",
   nonce: "n-0S6_WzA2Mj",
   client_metadata: {...},
-  presentation_definition: {...}
+  dcql_query: {...}
 }
 ```
 


### PR DESCRIPTION
Use dcql in #browser_api_request example rather than pe, which is an editorial change to a non-normative example that maybe kinda should have gone in https://github.com/openid/OpenID4VP/pull/254/files#r1811264551 