### PR TITLE
Add Multi RP Credentials/Authentication capability

### DIFF
--- a/examples/digital_credentials_api/signed_request_payload.json
+++ b/examples/digital_credentials_api/signed_request_payload.json
@@ -6,5 +6,19 @@
   "response_type": "vp_token",
   "response_mode": "dc_api.jwt",
   "nonce": "n-0S6_WzA2Mj",
-  "dcql_query": {...}
+  "dcql_query": {...},
+  "client_metadata": {
+    "jwks": {
+      "keys": [
+        {
+          "kty": "EC",
+          "crv": "P-256",
+          "x": "MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",
+          "y": "4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM",
+          "use": "enc",
+          "kid": "1"
+        }
+      ]
+    }
+  }
 }

--- a/examples/digital_credentials_api/signed_request_payload.json
+++ b/examples/digital_credentials_api/signed_request_payload.json
@@ -1,5 +1,4 @@
 {
-  "client_id": "https://client.example.org",
   "expected_origins": [
     "https://origin1.example.com",
     "https://origin2.example.com"
@@ -7,25 +6,5 @@
   "response_type": "vp_token",
   "response_mode": "dc_api.jwt",
   "nonce": "n-0S6_WzA2Mj",
-  "client_metadata": {
-    "vp_formats": {
-      "dc+sd-jwt": {
-        "sd-jwt_alg_values": [ "PS256" ],
-        "kb-jwt_alg_values": [ "PS256" ]
-      }
-    },
-    "jwks": {
-      "keys": [
-        {
-          "kty": "EC",
-          "crv": "P-256",
-          "x": "MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",
-          "y": "4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM",
-          "use": "enc",
-          "kid": "1"
-        }
-      ]
-    }
-  },
-  "presentation_definition": {...}
+  "dcql_query": {...}
 }

--- a/examples/digital_credentials_api/signed_request_payload_compact.json
+++ b/examples/digital_credentials_api/signed_request_payload_compact.json
@@ -1,0 +1,25 @@
+{
+  "expected_origins": [
+    "https://origin1.example.com",
+    "https://origin2.example.com"
+  ],
+  "client_id": "x509_san_dns:rp.example.com",
+  "client_metadata": {
+    "jwks": {
+      "keys": [
+        {
+          "kty": "EC",
+          "crv": "P-256",
+          "x": "MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",
+          "y": "4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM",
+          "use": "enc",
+          "kid": "1"
+        }
+      ]
+    }
+  },
+  "response_type": "vp_token",
+  "response_mode": "w3c_dc_api.jwt",
+  "nonce": "n-0S6_WzA2Mj",
+  "dcql_query": {...}
+}

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2275,7 +2275,7 @@ The signed request allows the Wallet to authenticate the Verifier using one or m
 
 The signed Request Object MAY contain all the parameters listed in (#browser_api_request), except `request`.
 
-The signed Request MUST use the JWS Serialization [@!RFC7515]). This allows the Verifier multiple Client Identifiers and corresponding key material and metadata when invoking a wallet. This is to serve use cases where the Verifier requests credentials belonging to different trust frameworks and thus must authenticate in the context of those trust frameworks.
+The signed Request MUST use the JWS Serialization [@!RFC7515]). This allows the Verifier multiple Client Identifiers and corresponding key material and metadata when invoking a Wallet. This is to serve use cases where the Verifier requests credentials belonging to different trust frameworks and thus must authenticate in the context of those trust frameworks.
 
 The following request parameters MUST be present in the protected header of the respective signature object: 
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2296,7 +2296,6 @@ The JWS JSON Serialization [@!RFC7515]) allows the Verifier to use multiple Clie
 In this case, the following request parameters MUST be present in the protected header of the respective `signature` object in the `signatures` array defined in [@!RFC7515, section 7.2.1]:
 
 * `client_id`
-* `client_metadata`
 
 All other request parameters MUST be present in the `payload` element of the JWS object.
 
@@ -2329,21 +2328,7 @@ This is an example of a protected header:
     "MIICOjCCAeG...djzH7lA==",
     "MIICLTCCAdS...koAmhWVKe"
   ],
-  "client_id": "x509_san_dns:rp.example.com",
-  "client_metadata": {
-    "jwks": {
-      "keys": [
-        {
-          "kty": "EC",
-          "crv": "P-256",
-          "x": "MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",
-          "y": "4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM",
-          "use": "enc",
-          "kid": "1"
-        }
-      ]
-    }
-  }
+  "client_id": "x509_san_dns:rp.example.com"
 }
 ```
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2325,7 +2325,6 @@ This is an example of a protected header:
 ```
 {
   "alg": "ES256",
-  "kid": "k2bdc",
   "x5c": [
     "MIICOjCCAeG...djzH7lA==",
     "MIICLTCCAdS...koAmhWVKe"

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2300,7 +2300,7 @@ This is an example of the payload of a signed OpenID4VP request used with the W3
 
 #### JWS JSON Serialization
 
-The JWS JSON Serialization [@!RFC7515]) allows the Verifier to use multiple Client Identifiers and corresponding key material and metadata for the same request. This is to serve use cases where the Verifier requests credentials belonging to different trust frameworks and thus must authenticate in the context of those trust frameworks.
+The JWS JSON Serialization [@!RFC7515]) allows the Verifier to use multiple Client Identifiers and corresponding key material and metadata to protect the same request. This serves use cases where the Verifier requests credentials belonging to different trust frameworks and, therefore, needs to authenticate in the context of those trust frameworks.
 
 In this case, the following request parameters MUST be present in the protected header of the respective signature object: 
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2285,11 +2285,11 @@ The following request parameters MUST be present in the protected header of the 
 Below is a non-normative example of such a request:
 
 ```js
-const credential = await navigator.identity.get({
+const credential = await navigator.credentials.get({
   digital: {
     providers: [{
       protocol: "openid4vp",
-      request: {
+      data: {
         "payload": "eyAiaXNzIjogImh0dHBzOi8...NzY4Mzc4MzYiIF0gfQ",
         "signatures": [
         {

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2303,26 +2303,19 @@ All other request parameters MUST be present in the `payload` element of the JWS
 Below is a non-normative example of such a request:
 
 ```js
-const credential = await navigator.credentials.get({
-  digital: {
-    providers: [{
-      protocol: "openid4vp",
-      data: {
-        "payload": "eyAiaXNzIjogImh0dHBzOi8...NzY4Mzc4MzYiIF0gfQ",
-        "signatures": [
-        {
-          "protected": "eyJhbGciOiAiRVMyNT..MiLCJraWQiOiAiMSJ9XX19fQ",
-          "signature": "PFwem0Ajp2Sag...T2z784h8TQqgTR9tXcif0jw"
-        },
-        {
-          "protected": "eyJhbGciOiAiRVMyNTY...tpZCI6ICIxIn1dfX19",
-          "signature": "irgtXbJGwE2wN4Lc...2TvUodsE0vaC-NXpB9G39cMXZ9A"
-        }
-      ]
-     }
-    }]
-  }
-});
+{
+  "payload": "eyAiaXNzIjogImh0dHBzOi8...NzY4Mzc4MzYiIF0gfQ",
+  "signatures": [
+    {
+      "protected": "eyJhbGciOiAiRVMyNT..MiLCJraWQiOiAiMSJ9XX19fQ",
+      "signature": "PFwem0Ajp2Sag...T2z784h8TQqgTR9tXcif0jw"
+    },
+    {
+      "protected": "eyJhbGciOiAiRVMyNTY...tpZCI6ICIxIn1dfX19",
+      "signature": "irgtXbJGwE2wN4Lc...2TvUodsE0vaC-NXpB9G39cMXZ9A"
+    }
+  ]
+}
 ```
 
 Every `signature` object in the structure contains the parameters and signature specific to a particular Client Identifier. The signature is calculated as specified in section 5.1 of [@!RFC7515].

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2334,7 +2334,7 @@ The following is a non-normative example of a content of a decoded protected hea
 }
 ```
 
-This is an example of the payload of a signed OpenID4VP request used with the W3C Digital Credentials API in conjunction with JWS JSON Serialization:
+The following is a non-normative example of the payload of a signed OpenID4VP request used with the W3C Digital Credentials API in conjunction with JWS JSON Serialization:
 
 <{{examples/digital_credentials_api/signed_request_payload.json}} 
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2323,7 +2323,7 @@ Every object in the `signatures` structure contains the parameters and the signa
 
 The following is a non-normative example of a content of a decoded protected header:
 
-```
+```json
 {
   "alg": "ES256",
   "x5c": [

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -3079,6 +3079,22 @@ established by [@!RFC7515].
 * Change Controller: OpenID Foundation Digital Credentials Protocols Working Group - openid-specs-digital-credentials-protocols@lists.openid.net
 * Specification Document(s): (#verifier_attestation_jwt) of this specification
 
+### client_id
+
+* Header Parameter Name: `client_id`
+* Header Parameter Description: This header contains a Client Identifier. 
+* Header Parameter Usage Location: JWS
+* Change Controller: IETF
+* Specification Document(s): [@!RFC6749]
+
+### client_metadata
+
+* Header Parameter Name: `jwt`
+* Header Parameter Description: This header contains a JWT. Processing rules MAY depend on the `typ` header value of the respective JWT. 
+* Header Parameter Usage Location: JWS
+* Change Controller: OpenID Foundation Digital Credentials Working Group - openid-specs-digital-credentials-protocols@lists.openid.net
+* Reference: (#vp_token_request) of this specification
+
 ## Uniform Resource Identifier (URI) Schemes Registry
 
 This specification registers the following URI scheme

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -3055,14 +3055,6 @@ established by [@!RFC7515].
 * Change Controller: IETF
 * Specification Document(s): [@!RFC6749]
 
-### client_metadata
-
-* Header Parameter Name: `client_metadata`
-* Header Parameter Description: A JSON object containing the Verifier metadata values as defined in (#new_parameters).
-* Header Parameter Usage Location: JWS
-* Change Controller: OpenID Foundation Digital Credentials Working Group - openid-specs-digital-credentials-protocols@lists.openid.net
-* Specification Document(s): (#vp_token_request) of this specification
-
 ## Uniform Resource Identifier (URI) Schemes Registry
 
 This specification registers the following URI scheme

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -3089,11 +3089,11 @@ established by [@!RFC7515].
 
 ### client_metadata
 
-* Header Parameter Name: `jwt`
-* Header Parameter Description: This header contains a JWT. Processing rules MAY depend on the `typ` header value of the respective JWT. 
+* Header Parameter Name: `client_metadata`
+* Header Parameter Description: A JSON object containing the Verifier metadata values as defined in (#new_parameters).
 * Header Parameter Usage Location: JWS
 * Change Controller: OpenID Foundation Digital Credentials Working Group - openid-specs-digital-credentials-protocols@lists.openid.net
-* Reference: (#vp_token_request) of this specification
+* Specification Document(s): (#vp_token_request) of this specification
 
 ## Uniform Resource Identifier (URI) Schemes Registry
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2275,7 +2275,7 @@ The signed request allows the Wallet to authenticate the Verifier using one or m
 
 The signed Request Object MAY contain all the parameters listed in (#browser_api_request), except `request`.
 
-The signed Request MUST use the JWS Serialization [@!RFC7515]). This allows the Verifier multiple Client Identifiers and corresponding key material and metadata when invoking a wallet. This is to serve use cases where the Verifier requests credentials belong to different transt framework and thus must authenticate in the context of those trust frameworks.
+The signed Request MUST use the JWS Serialization [@!RFC7515]). This allows the Verifier multiple Client Identifiers and corresponding key material and metadata when invoking a wallet. This is to serve use cases where the Verifier requests credentials belonging to different trust frameworks and thus must authenticate in the context of those trust frameworks.
 
 The following request parameter MUST be placed in the protect header of the respective signature object: 
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2279,7 +2279,9 @@ Verifiers can format signed Requests either using JWS Compact Serialization or J
 
 #### JWS Compact Serialization
 
-In case of the JWS Compact Serialization, all request parameters are encoded in a request object as defined in (#vp_token_request) and the JWS object is used as the value of the `request` claim in the `data` element of the API call. This is illustated in the following example.
+When the JWS Compact Serialization is used to send the request, the Verifier can convey only one Trust Framework, i.e., the Verifier should know which trust frameworks the wallet supports. All request parameters are encoded in a request object as defined in (#vp_token_request) and the JWS object is used as the value of the `request` claim in the `data` element of the API call. 
+
+This is illustrated in the following non-normative example.
 
 ```js
 { request: "eyJhbGciOiJF..." }

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2321,7 +2321,7 @@ Below is a non-normative example of such a request:
 
 Every object in the `signatures` structure contains the parameters and the signature specific to a particular Client Identifier. The signature is calculated as specified in section 5.1 of [@!RFC7515].
 
-This is an example of a protected header:
+The following is a non-normative example of a content of a decoded protected header:
 
 ```
 {

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2307,7 +2307,7 @@ const credential = await navigator.identity.get({
 });
 ```
 
-Every `signature` object in the structure contains the parameters and signature specific to a particular Client Identifier.
+Every `signature` object in the structure contains the parameters and signature specific to a particular Client Identifier. The signature is calculated as specified in section 5.1 of [@!RFC7515].
 
 This is an example of a protected header:
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2318,7 +2318,7 @@ Below is a non-normative example of such a request:
 }
 ```
 
-Every `signature` object in the structure contains the parameters and signature specific to a particular Client Identifier. The signature is calculated as specified in section 5.1 of [@!RFC7515].
+Every object in the `signatures` structure contains the parameters and the signature specific to a particular Client Identifier. The signature is calculated as specified in section 5.1 of [@!RFC7515].
 
 This is an example of a protected header:
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2275,12 +2275,39 @@ The signed request allows the Wallet to authenticate the Verifier using one or m
 
 The signed Request Object MAY contain all the parameters listed in (#browser_api_request), except `request`.
 
-The signed Request MUST use the JWS Serialization [@!RFC7515]). This allows the Verifier multiple Client Identifiers and corresponding key material and metadata when invoking a Wallet. This is to serve use cases where the Verifier requests credentials belonging to different trust frameworks and thus must authenticate in the context of those trust frameworks.
+Verifiers can format signed Requests either using JWS Compact Serialization or JWS Serialization [@!RFC7515]). 
 
-The following request parameters MUST be present in the protected header of the respective signature object: 
+#### JWS Compact Serialization
+
+In case of the JWS Compact Serialization, all request parameters are encoded in a request object as defined in (#vp_token_request) and the JWS object is used as value of the `request` claim in the `data` element of the API call. This is illustated in the following example.
+
+```js
+const credential = await navigator.credentials.get({
+  digital: {
+    providers: [{
+      protocol: "openid4vp",
+      data: {
+        { request: "eyJhbGciOiJF..." }
+     }
+    }]
+  }
+});
+```
+
+This is an example of the payload of a signed OpenID4VP request used with the W3C Digital Credentials API in conjunction with JWS Compact Serialization:
+
+<{{examples/digital_credentials_api/signed_request_payload_compact.json}} 
+
+#### JWS JSON Serialization
+
+The JWS JSON Serialization [@!RFC7515]) allows the Verifier to use multiple Client Identifiers and corresponding key material and metadata for the same request. This is to serve use cases where the Verifier requests credentials belonging to different trust frameworks and thus must authenticate in the context of those trust frameworks.
+
+In this case, the following request parameters MUST be present in the protected header of the respective signature object: 
 
 * `client_id`
 * `client_metadata`
+
+All other request parameters MUST be present in the `payload` element of the JWS object.
 
 Below is a non-normative example of such a request:
 
@@ -2293,11 +2320,11 @@ const credential = await navigator.credentials.get({
         "payload": "eyAiaXNzIjogImh0dHBzOi8...NzY4Mzc4MzYiIF0gfQ",
         "signatures": [
         {
-          "protected": "eyJhbGciOiJFUzI1NiJ9",
+          "protected": "eyJhbGciOiAiRVMyNT..MiLCJraWQiOiAiMSJ9XX19fQ",
           "signature": "PFwem0Ajp2Sag...T2z784h8TQqgTR9tXcif0jw"
         },
         {
-          "protected": "eyJhbGciOiJFUzI1NiJ9",
+          "protected": "eyJhbGciOiAiRVMyNTY...tpZCI6ICIxIn1dfX19",
           "signature": "irgtXbJGwE2wN4Lc...2TvUodsE0vaC-NXpB9G39cMXZ9A"
         }
       ]
@@ -2337,7 +2364,7 @@ This is an example of a protected header:
 }
 ```
 
-This is an example of the payload of a signed OpenID4VP request used with the DC API:
+This is an example of the payload of a signed OpenID4VP request used with the W3C Digital Credentials API in conjunction with JWS JSON Serialization:
 
 <{{examples/digital_credentials_api/signed_request_payload.json}} 
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -3052,7 +3052,7 @@ established by [@!RFC7515].
 ### client_id
 
 * Header Parameter Name: `client_id`
-* Header Parameter Description: This header contains a Client Identifier. 
+* Header Parameter Description: This header contains a Client Identifier. A Client Identifier is used in OAuth to identify a certain client. It is defined in [@!RFC6749], section 2.2.
 * Header Parameter Usage Location: JWS
 * Change Controller: IETF
 * Specification Document(s): [@!RFC6749]

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2291,7 +2291,7 @@ This is an example of the payload of a signed OpenID4VP request used with the W3
 
 #### JWS JSON Serialization
 
-The JWS JSON Serialization [@!RFC7515]) allows the Verifier to use multiple Client Identifiers and corresponding key material and metadata to protect the same request. This serves use cases where the Verifier requests credentials belonging to different trust frameworks and, therefore, needs to authenticate in the context of those trust frameworks.
+The JWS JSON Serialization [@!RFC7515]) allows the Verifier to use multiple Client Identifiers and corresponding key material and metadata to protect the same request. This serves use cases where the Verifier requests Credentials belonging to different trust frameworks and, therefore, needs to authenticate in the context of those trust frameworks.
 
 In this case, the following request parameters MUST be present in the protected header of the respective `signature` object in the `signatures` array defined in [@!RFC7515, section 7.2.1]:
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2282,16 +2282,7 @@ Verifiers can format signed Requests either using JWS Compact Serialization or J
 In case of the JWS Compact Serialization, all request parameters are encoded in a request object as defined in (#vp_token_request) and the JWS object is used as the value of the `request` claim in the `data` element of the API call. This is illustated in the following example.
 
 ```js
-const credential = await navigator.credentials.get({
-  digital: {
-    providers: [{
-      protocol: "openid4vp",
-      data: {
-        { request: "eyJhbGciOiJF..." }
-     }
-    }]
-  }
-});
+{ request: "eyJhbGciOiJF..." }
 ```
 
 This is an example of the payload of a signed OpenID4VP request used with the W3C Digital Credentials API in conjunction with JWS Compact Serialization:

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2293,7 +2293,7 @@ This is an example of the payload of a signed OpenID4VP request used with the W3
 
 The JWS JSON Serialization [@!RFC7515]) allows the Verifier to use multiple Client Identifiers and corresponding key material and metadata to protect the same request. This serves use cases where the Verifier requests credentials belonging to different trust frameworks and, therefore, needs to authenticate in the context of those trust frameworks.
 
-In this case, the following request parameters MUST be present in the protected header of the respective `signature` object: 
+In this case, the following request parameters MUST be present in the protected header of the respective `signature` object in the `signatures` array defined in [@!RFC7515, section 7.2.1]:
 
 * `client_id`
 * `client_metadata`

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2277,7 +2277,7 @@ The signed Request Object MAY contain all the parameters listed in (#browser_api
 
 The signed Request MUST use the JWS Serialization [@!RFC7515]). This allows the Verifier multiple Client Identifiers and corresponding key material and metadata when invoking a wallet. This is to serve use cases where the Verifier requests credentials belonging to different trust frameworks and thus must authenticate in the context of those trust frameworks.
 
-The following request parameter MUST be placed in the protect header of the respective signature object: 
+The following request parameters MUST be present in the protected header of the respective signature object: 
 
 * `client_id`
 * `client_metadata`

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2275,7 +2275,7 @@ The signed request allows the Wallet to authenticate the Verifier using one or m
 
 The signed Request Object MAY contain all the parameters listed in (#dc_api_request), except `request`.
 
-Verifiers can format signed Requests either using JWS Compact Serialization or JWS Serialization [@!RFC7515]). 
+Verifiers can format signed Requests either using JWS Compact Serialization or JWS JSON Serialization [@!RFC7515]). 
 
 #### JWS Compact Serialization
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2273,7 +2273,7 @@ The Verifier MAY send a signed request, for example, when identification and aut
 
 The signed request allows the Wallet to authenticate the Verifier using one or more trust framework(s) in addition to the Web PKI utilized by the browser. An example of such a trust framework is the Verifier (RP) management infrastructure set up in the context of the eIDAS regulation in the European Union, in which case, the Wallet can no longer rely only on the web origin of the Verifier. This web origin MAY still be used to further strengthen the security of the flow. The external trust framework could, for example, map the Client Identifier to registered web origins.
 
-The signed Request Object MAY contain all the parameters listed in (#browser_api_request), except `request`.
+The signed Request Object MAY contain all the parameters listed in (#dc_api_request), except `request`.
 
 Verifiers can format signed Requests either using JWS Compact Serialization or JWS Serialization [@!RFC7515]). 
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -3123,6 +3123,7 @@ The technology described in this specification was made available from contribut
    * remove x509_san_uri client identifier scheme
    * clarify that `dcql_query` and `presentation_definition` are passed as JSON objects (not strings) in request objects
    * support returning multiple presentations for a single dcql credential query when requested using `multiple`
+   * Added support for multiple Client Identifiers and corresponding Request Signature to the DC API profile
 
    -24
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2293,7 +2293,7 @@ This is an example of the payload of a signed OpenID4VP request used with the W3
 
 #### JWS JSON Serialization
 
-The JWS JSON Serialization [@!RFC7515]) allows the Verifier to use multiple Client Identifiers and corresponding key material and metadata to protect the same request. This serves use cases where the Verifier requests Credentials belonging to different trust frameworks and, therefore, needs to authenticate in the context of those trust frameworks.
+The JWS JSON Serialization [@!RFC7515]) allows the Verifier to use multiple Client Identifiers and corresponding key material to protect the same request. This serves use cases where the Verifier requests Credentials belonging to different trust frameworks and, therefore, needs to authenticate in the context of those trust frameworks.
 
 In this case, the following request parameters MUST be present in the protected header of the respective `signature` object in the `signatures` array defined in [@!RFC7515, section 7.2.1]:
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2303,7 +2303,7 @@ All other request parameters MUST be present in the `payload` element of the JWS
 
 Below is a non-normative example of such a request:
 
-```js
+```json
 {
   "payload": "eyAiaXNzIjogImh0dHBzOi8...NzY4Mzc4MzYiIF0gfQ",
   "signatures": [

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2302,7 +2302,7 @@ This is an example of the payload of a signed OpenID4VP request used with the W3
 
 The JWS JSON Serialization [@!RFC7515]) allows the Verifier to use multiple Client Identifiers and corresponding key material and metadata to protect the same request. This serves use cases where the Verifier requests credentials belonging to different trust frameworks and, therefore, needs to authenticate in the context of those trust frameworks.
 
-In this case, the following request parameters MUST be present in the protected header of the respective signature object: 
+In this case, the following request parameters MUST be present in the protected header of the respective `signature` object: 
 
 * `client_id`
 * `client_metadata`

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2275,7 +2275,7 @@ The signed request allows the Wallet to authenticate the Verifier using one or m
 
 The signed Request Object MAY contain all the parameters listed in (#dc_api_request), except `request`.
 
-Verifiers can format signed Requests either using JWS Compact Serialization or JWS JSON Serialization [@!RFC7515]). 
+Verifiers SHOULD format signed Requests using JWS Compact Serialization but MAY use JWS JSON Serialization [@!RFC7515]) to cater for use cases described below. 
 
 #### JWS Compact Serialization
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2279,7 +2279,7 @@ Verifiers can format signed Requests either using JWS Compact Serialization or J
 
 #### JWS Compact Serialization
 
-In case of the JWS Compact Serialization, all request parameters are encoded in a request object as defined in (#vp_token_request) and the JWS object is used as value of the `request` claim in the `data` element of the API call. This is illustated in the following example.
+In case of the JWS Compact Serialization, all request parameters are encoded in a request object as defined in (#vp_token_request) and the JWS object is used as the value of the `request` claim in the `data` element of the API call. This is illustated in the following example.
 
 ```js
 const credential = await navigator.credentials.get({

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2271,7 +2271,7 @@ The Verifier MAY send all the OpenID4VP request parameters as members in the req
 
 The Verifier MAY send a signed request, for example, when identification and authentication of the Verifier is required.
 
-The signed request allows the Wallet to authenticate the Verifier using one or more trust framework(s) other than the Web PKI utilized by the browser. An example of such a trust framework is the Verifier (RP) management infrastructure set up in the context of the eIDAS regulation in the European Union, in which case, the Wallet can no longer rely only on the web origin of the Verifier. This web origin MAY still be used to further strengthen the security of the flow. The external trust framework could, for example, map the Client Identifier to registered web origins.
+The signed request allows the Wallet to authenticate the Verifier using one or more trust framework(s) in addition to the Web PKI utilized by the browser. An example of such a trust framework is the Verifier (RP) management infrastructure set up in the context of the eIDAS regulation in the European Union, in which case, the Wallet can no longer rely only on the web origin of the Verifier. This web origin MAY still be used to further strengthen the security of the flow. The external trust framework could, for example, map the Client Identifier to registered web origins.
 
 The signed Request Object MAY contain all the parameters listed in (#browser_api_request), except `request`.
 


### PR DESCRIPTION
This PR changes the way requests are signed to the Digital Credentials API from compact serialization (single RP) to JWS JSON Serialization (Multiple RPs).
Questions to the WG:
- Do you want to keep (re-add) the JWS Compact Serialization to the Digital Credentials API profile?
- Do we want the Multi RP capability to the traditional OID4VP flow?

resolves #248 