### PR TITLE
Fix an example authorization request to say 'wallet' instead of 'client'

### DIFF
--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -523,7 +523,7 @@ The following is a non-normative example of a request with this Client Identifie
 
 ```
 HTTP/1.1 302 Found
-Location: https://client.example.org/universal-link?
+Location: https://wallet.example.org/universal-link?
   response_type=vp_token
   &client_id=redirect_uri:https%3A%2F%2Fclient.example.org%2Fcb
   &redirect_uri=https%3A%2F%2Fclient.example.org%2Fcb


### PR DESCRIPTION
The authz request goes to the wallet so it was confusing how it was. We use wallet.example.com elsewhere in the spec so use that.