### PR TITLE
Make SIOP example requests/response consistent

### DIFF
--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2350,7 +2350,7 @@ GET /authorize?
   response_type=vp_token%20id_token
   &scope=openid
   &id_token_type=subject_signed
-  &client_id=https%3A%2F%2Fclient.example.org%2Fcb
+  &client_id=x509_san_uri%3Ahttps%3A%2F%2Fclient.example.org%2Fcb
   &redirect_uri=https%3A%2F%2Fclient.example.org%2Fcb
   &presentation_definition=...
   &nonce=n-0S6_WzA2Mj HTTP/1.1


### PR DESCRIPTION
The example SIOP request didn't include the x509_san_uri scheme, but the example self issued id token in the example response includes it.

Include it in the request just for self-consistency.