### PR TITLE
note on encryption choices (JARM)

### DIFF
--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -1155,6 +1155,8 @@ To obtain Verifier's public key for the input to the key agreement to encrypt th
 
 To sign the Authorization Response, the Wallet MUST use a private key that corresponds to a public key made available in its metadata.
 
+Note: For encryption, implementers can utilize the different options provided by JOSE, including variants like Hybrid Public Key Encryption (HPKE) as introduced in [@I-D.ietf-jose-hpke-encrypt].
+
 ### Response Mode "direct_post.jwt" {#direct_post_jwt}
 
 This specification also defines a new Response Mode `direct_post.jwt`, which allows for JARM to be used with Response Mode `direct_post` defined in (#response_mode_post).


### PR DESCRIPTION
Editorial note as briefly discussed in last weeks DCP calls and mentioned in #310 to mention HPKE as one of the choices for encryption.