### PR TITLE
Change note about SD-KWT KB JWT nonce/aud to be normative

### DIFF
--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2339,7 +2339,12 @@ Setting `limit_disclosure` property defined in [@!DIF.PresentationExchange] to `
 
 A non-normative example of the Authorization Response would look the same as in the examples of other Credential formats in this Annex.
 
-The Key Binding JWT `nonce` claim MUST be the value of `nonce` from the authorization request, and the `aud` claim MUST be the Client Identifier of the Verifier.
+The following requirements apply to the `nonce` and `aud` claims in the Key Binding JWT:
+
+- the `nonce` claim MUST be the value of `nonce` from the Authorization Request;
+- the `aud` claim MUST be the value of the Client Identifier; 
+
+Note that for an unsigned Authorization Request over the DC API the `client_id` parameter is not used and the effective Client Identifier is derived from the origin received from the platform as described in (#dc_api_request).
 
 The `transaction_data_hashes` response parameter defined in (#transaction_data) MUST be included in the Key Binding JWT as a top level claim. This means that transaction data mechanism cannot be used with SD-JWT VCs without cryptographic key binding and, therefore, do not use KB JWT.
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2339,6 +2339,8 @@ Setting `limit_disclosure` property defined in [@!DIF.PresentationExchange] to `
 
 A non-normative example of the Authorization Response would look the same as in the examples of other Credential formats in this Annex.
 
+The Key Binding JWT `nonce` claim MUST be the value of `nonce` from the authorization request, and the `aud` claim MUST be the Client Identifier of the Verifier.
+
 The `transaction_data_hashes` response parameter defined in (#transaction_data) MUST be included in the Key Binding JWT as a top level claim. This means that transaction data mechanism cannot be used with SD-JWT VCs without cryptographic key binding and, therefore, do not use KB JWT.
 
 The following is a non-normative example of the content of the `presentation_submission` parameter:
@@ -2354,8 +2356,6 @@ In this example the `vp_token` contains only the disclosures for the claims spec
 The following is a non-normative example of the unsecured payload of the Key Binding JWT.
 
 <{{examples/response/kb_jwt_unsecured.json}}
-
-Note: The Key Binding JWT `nonce` claim contains the value of the `nonce` from the authorization request, and the `aud` claim contains the Client Identifier of the Verifier.
 
 ## Combining this specification with SIOPv2
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2344,7 +2344,7 @@ The following requirements apply to the `nonce` and `aud` claims in the Key Bind
 - the `nonce` claim MUST be the value of `nonce` from the Authorization Request;
 - the `aud` claim MUST be the value of the Client Identifier; 
 
-Note that for an unsigned Authorization Request over the DC API the `client_id` parameter is not used and the effective Client Identifier is derived from the origin received from the platform as described in (#dc_api_request).
+Note that for an unsigned Authorization Request over the DC API, the `client_id` parameter is not used. Instead, the effective Client Identifier is derived from the origin received from the platform, as described in (#dc_api_request).
 
 The `transaction_data_hashes` response parameter defined in (#transaction_data) MUST be included in the Key Binding JWT as a top level claim. This means that transaction data mechanism cannot be used with SD-JWT VCs without cryptographic key binding and, therefore, do not use KB JWT.
 


### PR DESCRIPTION
I'm not sure why this was flagged as a note, it's the only place across SD-JWT/SD-JWT VC/OID4VP/HAIP that actually defines this behaviour. Also move it up a few paragraphs as it seems better to have all the normative text in this section together.

closes #350