### PR TITLE
Clarify that non-JARM error response may be sent even when JARM requested

### DIFF
--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -1144,6 +1144,8 @@ This specification also defines a new Response Mode `direct_post.jwt`, which all
 
 The Response Mode `direct_post.jwt` causes the Wallet to send the Authorization Response using an HTTP POST request instead of redirecting back to the Verifier as defined in (#response_mode_post). The Wallet adds the `response` parameter containing the JWT as defined in Section 4.1. of [@!JARM] and (#jarm) in the body of an HTTP POST request using the `application/x-www-form-urlencoded` content type. The names and values in the body MUST be encoded using UTF-8.
 
+If a Wallet is unable to send a JARM response it MAY send an error response as per (#response_mode_post).
+
 The following is a non-normative example of a response using the `presentation_submission` and `vp_token` values from (#jwt_vc). (line breaks for display purposes only):
 
 <{{examples/response/jarm_jwt_vc_json_post.txt}}

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -1144,7 +1144,7 @@ This specification also defines a new Response Mode `direct_post.jwt`, which all
 
 The Response Mode `direct_post.jwt` causes the Wallet to send the Authorization Response using an HTTP POST request instead of redirecting back to the Verifier as defined in (#response_mode_post). The Wallet adds the `response` parameter containing the JWT as defined in Section 4.1. of [@!JARM] and (#jarm) in the body of an HTTP POST request using the `application/x-www-form-urlencoded` content type. The names and values in the body MUST be encoded using UTF-8.
 
-If a Wallet is unable to send a JARM response it MAY send an error response as per (#response_mode_post).
+If a Wallet is unable to generate a JARM response, it MAY send an error response without using JARM as per (#response_mode_post).
 
 The following is a non-normative example of a response using the `presentation_submission` and `vp_token` values from (#jwt_vc). (line breaks for display purposes only):
 


### PR DESCRIPTION
Even if the Verifier requests direct_post.jwt, the Wallet may be unable to do so for various reasons including the Verifier not supplying keys or encryption algorithms. Allow a direct_post error response to allow for those and other cases.

closes #135