### PR TITLE
Add version and request type to protocol identifier for DC API

### DIFF
--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -1960,7 +1960,7 @@ And lastly, as part of the request, the Wallet is provided with information abou
 
 To use OpenID4VP with the Digital Credentials API (DC API), the exchange protocol value has the following format: `urn:openid:protocol:openid4vp:v<version>:<request-type>`. The `<version>` field is a numeric value, and `<request-type>` explicitly specifies the type of request. This approach eliminates the need for Wallets to perform implicit parameter matching to accurately identify the version and the expected request and response parameters.
 
-The value `1` MUST be used for the `<version>` field to indicate the request and response conform to this version of the specification. For `<request-type>`, unsigned requests, as defined in (#unsigned_request), MUST use `unsigned`, and signed requests, as defined in (#signed_request), MUST use `signed`.
+The value `1` MUST be used for the `<version>` field to indicate the request and response are compatible with this version of the specification. For `<request-type>`, unsigned requests, as defined in (#unsigned_request), MUST use `unsigned`, and signed requests, as defined in (#signed_request), MUST use `signed`.
 
 The following exchange protocol values are defined by this specification:
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -1960,7 +1960,7 @@ And lastly, as part of the request, the Wallet is provided with information abou
 
 To use OpenID4VP with the Digital Credentials API (DC API), the exchange protocol value has the following format: `urn:openid:protocol:oid4vp:<version>:<request-type>`. The `<version>` field adheres to semantic versioning, and `<request-type>` explicitly specifies the type of request. This approach eliminates the need for wallets to perform implicit parameter matching to accurately identify the version and the expected request and response parameters.
 
-This specification defines `1.0` as the value for the `<version>` field. For `<request-type>`, unsigned requests, as defined in (#unsigned_request), use `unsigned`, and signed requests, as defined in (#signed_request), use `signed`.
+The value `1.0` MUST be used for the `<version>` field to indicate the request and response conform to this version of the specification. For `<request-type>`, unsigned requests, as defined in (#unsigned_request), MUST use `unsigned`, and signed requests, as defined in (#signed_request), MUST use `signed`.
 
 The following exchange protocol values are defined by this specification:
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -1964,8 +1964,8 @@ The value `1` MUST be used for the `<version>` field to indicate the request and
 
 The following exchange protocol values are defined by this specification:
 
-* Unsigned requests: `urn:openid:protocol:openid4vp:v1:unsigned`
-* Signed requests: `urn:openid:protocol:openid4vp:v1:signed`
+* Unsigned requests: `urn:openid:dcapi-protocol:openid4vp:v1:unsigned`
+* Signed requests: `urn:openid:dcapi-protocol:openid4vp:v1:signed`
 
 ## Request {#dc_api_request}
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -1958,14 +1958,14 @@ And lastly, as part of the request, the Wallet is provided with information abou
 
 ## Protocol
 
-To use OpenID4VP with the Digital Credentials API (DC API), the exchange protocol value has the following format: `urn:openid:protocol:openid4vp:<version>:<request-type>`. The `<version>` field adheres to semantic versioning, and `<request-type>` explicitly specifies the type of request. This approach eliminates the need for Wallets to perform implicit parameter matching to accurately identify the version and the expected request and response parameters.
+To use OpenID4VP with the Digital Credentials API (DC API), the exchange protocol value has the following format: `urn:openid:protocol:openid4vp:v<version>:<request-type>`. The `<version>` field is a numeric value, and `<request-type>` explicitly specifies the type of request. This approach eliminates the need for Wallets to perform implicit parameter matching to accurately identify the version and the expected request and response parameters.
 
-The value `1.0` MUST be used for the `<version>` field to indicate the request and response conform to this version of the specification. For `<request-type>`, unsigned requests, as defined in (#unsigned_request), MUST use `unsigned`, and signed requests, as defined in (#signed_request), MUST use `signed`.
+The value `1` MUST be used for the `<version>` field to indicate the request and response conform to this version of the specification. For `<request-type>`, unsigned requests, as defined in (#unsigned_request), MUST use `unsigned`, and signed requests, as defined in (#signed_request), MUST use `signed`.
 
 The following exchange protocol values are defined by this specification:
 
-* Unsigned requests: `urn:openid:protocol:openid4vp:1.0:unsigned`
-* Signed requests: `urn:openid:protocol:openid4vp:1.0:signed`
+* Unsigned requests: `urn:openid:protocol:openid4vp:v1:unsigned`
+* Signed requests: `urn:openid:protocol:openid4vp:v1:signed`
 
 ## Request {#dc_api_request}
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -1958,14 +1958,14 @@ And lastly, as part of the request, the Wallet is provided with information abou
 
 ## Protocol
 
-To use OpenID4VP with the Digital Credentials API (DC API), the exchange protocol value has the following format: `urn:openid:protocol:oid4vp:<version>:<request-type>`. The `<version>` field adheres to semantic versioning, and `<request-type>` explicitly specifies the type of request. This approach eliminates the need for wallets to perform implicit parameter matching to accurately identify the version and the expected request and response parameters.
+To use OpenID4VP with the Digital Credentials API (DC API), the exchange protocol value has the following format: `urn:openid:protocol:openid4vp:<version>:<request-type>`. The `<version>` field adheres to semantic versioning, and `<request-type>` explicitly specifies the type of request. This approach eliminates the need for wallets to perform implicit parameter matching to accurately identify the version and the expected request and response parameters.
 
 The value `1.0` MUST be used for the `<version>` field to indicate the request and response conform to this version of the specification. For `<request-type>`, unsigned requests, as defined in (#unsigned_request), MUST use `unsigned`, and signed requests, as defined in (#signed_request), MUST use `signed`.
 
 The following exchange protocol values are defined by this specification:
 
-* Unsigned requests: `urn:openid:protocol:oid4vp:1.0:unsigned`
-* Signed requests: `urn:openid:protocol:oid4vp:1.0:signed`
+* Unsigned requests: `urn:openid:protocol:openid4vp:1.0:unsigned`
+* Signed requests: `urn:openid:protocol:openid4vp:1.0:signed`
 
 ## Request {#dc_api_request}
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -1958,7 +1958,7 @@ And lastly, as part of the request, the Wallet is provided with information abou
 
 ## Protocol
 
-To use OpenID4VP with the Digital Credentials API (DC API), the exchange protocol value has the following format: `urn:openid:protocol:openid4vp:<version>:<request-type>`. The `<version>` field adheres to semantic versioning, and `<request-type>` explicitly specifies the type of request. This approach eliminates the need for wallets to perform implicit parameter matching to accurately identify the version and the expected request and response parameters.
+To use OpenID4VP with the Digital Credentials API (DC API), the exchange protocol value has the following format: `urn:openid:protocol:openid4vp:<version>:<request-type>`. The `<version>` field adheres to semantic versioning, and `<request-type>` explicitly specifies the type of request. This approach eliminates the need for Wallets to perform implicit parameter matching to accurately identify the version and the expected request and response parameters.
 
 The value `1.0` MUST be used for the `<version>` field to indicate the request and response conform to this version of the specification. For `<request-type>`, unsigned requests, as defined in (#unsigned_request), MUST use `unsigned`, and signed requests, as defined in (#signed_request), MUST use `signed`.
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -1958,7 +1958,14 @@ And lastly, as part of the request, the Wallet is provided with information abou
 
 ## Protocol
 
-To use OpenID4VP over the DC API, the value of the exchange protocol used with the Digital Credentials API (DC API), is `openid4vp`.
+To use OpenID4VP with the Digital Credentials API (DC API), the exchange protocol value has the following format: `urn:openid:protocol:oid4vp:<version>:<request-type>`. The `<version>` field adheres to semantic versioning, and `<request-type>` explicitly specifies the type of request. This approach eliminates the need for wallets to perform implicit parameter matching to accurately identify the version and the expected request and response parameters.
+
+This specification defines `1.0` as the value for the `<version>` field. For `<request-type>`, unsigned requests, as defined in (#unsigned_request), use `unsigned`, and signed requests, as defined in (#signed_request), use `signed`.
+
+The following exchange protocol values are defined by this specification:
+
+* Unsigned requests: `urn:openid:protocol:oid4vp:1.0:unsigned`
+* Signed requests: `urn:openid:protocol:oid4vp:1.0:signed`
 
 ## Request {#dc_api_request}
 


### PR DESCRIPTION
This PR adds version and request type to the protocol identifier for DC API.

Fixes #326, fixes #363