### PR TITLE
Swap URN for dash delimited protocol identifer

### DIFF
--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2000,14 +2000,14 @@ And lastly, as part of the request, the Wallet is provided with information abou
 
 ## Protocol
 
-To use OpenID4VP with the Digital Credentials API (DC API), the exchange protocol value has the following format: `urn:openid:protocol:openid4vp:v<version>:<request-type>`. The `<version>` field is a numeric value, and `<request-type>` explicitly specifies the type of request. This approach eliminates the need for Wallets to perform implicit parameter matching to accurately identify the version and the expected request and response parameters.
+To use OpenID4VP with the Digital Credentials API (DC API), the exchange protocol value has the following format: `openid4vp-v<version>-<request-type>`. The `<version>` field is a numeric value, and `<request-type>` explicitly specifies the type of request. This approach eliminates the need for Wallets to perform implicit parameter matching to accurately identify the version and the expected request and response parameters.
 
 The value `1` MUST be used for the `<version>` field to indicate the request and response are compatible with this version of the specification. For `<request-type>`, unsigned requests, as defined in (#unsigned_request), MUST use `unsigned`, and signed requests, as defined in (#signed_request), MUST use `signed`.
 
 The following exchange protocol values are defined by this specification:
 
-* Unsigned requests: `urn:openid:dcapi-protocol:openid4vp:v1:unsigned`
-* Signed requests: `urn:openid:dcapi-protocol:openid4vp:v1:signed`
+* Unsigned requests: `openid4vp-v1-unsigned`
+* Signed requests: `openid4vp-v1-signed`
 
 ## Request {#dc_api_request}
 


### PR DESCRIPTION
After all the discussion on the protocol identifier, unfortunately a URN is not going to work. [W3C TAG has guidelines for enum strings, where only dashes can be used for separation](https://github.com/WICG/digital-credentials/issues/191#issuecomment-2661685099).

After discussion on the 2025-02-19 DC API call, this PR changes the URN to a dash delimited identifier (and removes URN specific things like "urn", org, and "protocol".

/cc @bc-pi 