### PR TITLE
add example for sessiontranscript related structures

### DIFF
--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2360,26 +2360,26 @@ The following is a non-normative example of the `OpenID4VPDCAPIHandoverInfo` str
 ```
 Hex:
 
-837368747470733a2f2f6578616d706c652e636f6d781e7765622d6f726967696e3a68747470733a2f2f6578616d706c652e636f6d782b313141457a39684f5375354c5f666f43474a776c5765454c6f525458636433627a6a5350725a376956446b
+837368747470733a2f2f6578616d706c652e636f6d782b4c346167535859767664706b7a6663345666506a4768715a73736e756a64723748436a742d62444c6d7041782b516f50736b6e726738676a6171693043616f46504b794c6370537a34585f71505034596d7872316d6b4563
 
 CBOR diagnostic:
 
 83                                                # array(3)
   73                                              #   string(19)
     68747470733a2f2f6578616d706c652e636f6d        #     "https://example.com"
-  78 1e                                           #   string(30)
-    7765622d6f726967696e3a68747470733a2f2f657861  #     "web-origin:https://exa"
-    6d706c652e636f6d                              #     "mple.com"
   78 2b                                           #   string(43)
-    313141457a39684f5375354c5f666f43474a776c5765  #     "11AEz9hOSu5L_foCGJwlWe"
-    454c6f525458636433627a6a5350725a376956446b    #     "ELoRTXcd3bzjSPrZ7iVDk"
+    4c346167535859767664706b7a6663345666506a4768  #     "L4agSXYvvdpkzfc4VfPjGh"
+    715a73736e756a64723748436a742d62444c6d7041    #     "qZssnujdr7HCjt-bDLmpA"
+  78 2b                                           #   string(43)
+    516f50736b6e726738676a6171693043616f46504b79  #     "QoPsknrg8gjaqi0CaoFPKy"
+    4c6370537a34585f71505034596d7872316d6b4563    #     "LcpSz4X_qPP4Ymxr1mkEc"
 ```
 
 The following is a non-normative example of the `OpenID4VPDCAPIHandover` structure:
 ```
 Hex:
 
-82764f70656e4944345650444341504948616e646f7665725820507ee40d57b7d0c4f82d7c7e140a4b2d44753970d085729ea1f2cfa98243b08f
+82764f70656e4944345650444341504948616e646f76657258203f94de36e3292c1ded4511cd48450da3e787afeead8732cc013bd7acb9870626
 
 CBOR diagnostic:
 
@@ -2387,15 +2387,15 @@ CBOR diagnostic:
   76                                              #   string(22)
     4f70656e4944345650444341504948616e646f766572  #     "OpenID4VPDCAPIHandover"
   58 20                                           #   bytes(32)
-    507ee40d57b7d0c4f82d7c7e140a4b2d44753970d085  #     "P~ä\x0dW·ÐÄø-|~\x14\x0aK-Du9pÐ\x85"
-    729ea1f2cfa98243b08f                          #     "r\x9e¡òÏ©\x82C°\x8f"
+    3f94de36e3292c1ded4511cd48450da3e787afeead87  #     "?\x94Þ6ã),\x1díE\x11ÍHE\x0d£ç\x87¯î\xad\x87"
+    32cc013bd7acb9870626                          #     "2Ì\x01;×¬¹\x87\x06&"
 ```
 
 The following is a non-normative example of the `SessionTranscript` structure:
 ```
 Hex:
 
-83f6f682764f70656e4944345650444341504948616e646f7665725820507ee40d57b7d0c4f82d7c7e140a4b2d44753970d085729ea1f2cfa98243b08f
+83f6f682764f70656e4944345650444341504948616e646f76657258203f94de36e3292c1ded4511cd48450da3e787afeead8732cc013bd7acb9870626
 
 CBOR diagnostic:
 
@@ -2407,8 +2407,8 @@ CBOR diagnostic:
       4f70656e4944345650444341504948616e646f7665  #       "OpenID4VPDCAPIHandove"
       72                                          #       "r"
     58 20                                         #     bytes(32)
-      507ee40d57b7d0c4f82d7c7e140a4b2d44753970d0  #       "P~ä\x0dW·ÐÄø-|~\x14\x0aK-Du9pÐ"
-      85729ea1f2cfa98243b08f                      #       "\x85r\x9e¡òÏ©\x82C°\x8f"
+      3f94de36e3292c1ded4511cd48450da3e787afeead  #       "?\x94Þ6ã),\x1díE\x11ÍHE\x0d£ç\x87¯î\xad"
+      8732cc013bd7acb9870626                      #       "\x872Ì\x01;×¬¹\x87\x06&"
 ```
 
 #### Invocation via other methods {#non-dc-api-invocation}

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2356,7 +2356,7 @@ The `OpenID4VPDCAPIHandover` structure has the following elements:
   * The second element MUST be the value of the effective Client Identifier as defined in (#dc_api_request).
   * The third element MUST be the value of the `nonce` request parameter.
 
-The following is a non-normative example of the input JWK for the JWK Thumbprint for the `OpenID4VPDCAPIHandoverInfo`:
+The following is a non-normative example of the input JWK for calculating the JWK Thumbprint in the context of `OpenID4VPDCAPIHandoverInfo`:
 ```json
 {
   "kty": "EC",

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2373,7 +2373,7 @@ The following is a non-normative example of the `OpenID4VPDCAPIHandoverInfo` str
 ```
 Hex:
 
-837368747470733a2f2f6578616d706c652e636f6d782b4c346167535859767664706b7a6663345666506a4768715a73736e756a64723748436a742d62444c6d7041782b516f50736b6e726738676a6171693043616f46504b794c6370537a34585f71505034596d7872316d6b4563
+837368747470733a2f2f6578616d706c652e636f6d782b6578633767426b786a7831726463397564527276654b7653734a4971383061766c58654c4868477771744158204283ec927ae0f208daaa2d026a814f2b22dca52cf85ffa8f3f8626c6bd669047
 
 CBOR diagnostic:
 
@@ -2381,18 +2381,18 @@ CBOR diagnostic:
   73                                              #   string(19)
     68747470733a2f2f6578616d706c652e636f6d        #     "https://example.com"
   78 2b                                           #   string(43)
-    4c346167535859767664706b7a6663345666506a4768  #     "L4agSXYvvdpkzfc4VfPjGh"
-    715a73736e756a64723748436a742d62444c6d7041    #     "qZssnujdr7HCjt-bDLmpA"
-  78 2b                                           #   string(43)
-    516f50736b6e726738676a6171693043616f46504b79  #     "QoPsknrg8gjaqi0CaoFPKy"
-    4c6370537a34585f71505034596d7872316d6b4563    #     "LcpSz4X_qPP4Ymxr1mkEc"
+    6578633767426b786a7831726463397564527276654b  #     "exc7gBkxjx1rdc9udRrveK"
+    7653734a4971383061766c58654c48684777717441    #     "vSsJIq80avlXeLHhGwqtA"
+  58 20                                           #   bytes(32)
+    4283ec927ae0f208daaa2d026a814f2b22dca52cf85f  #     "B\x83ì\x92zàò\x08Úª-\x02j\x81O+"Ü¥,ø_"
+    fa8f3f8626c6bd669047                          #     "ú\x8f?\x86&Æ½f\x90G"
 ```
 
 The following is a non-normative example of the `OpenID4VPDCAPIHandover` structure:
 ```
 Hex:
 
-82764f70656e4944345650444341504948616e646f76657258203f94de36e3292c1ded4511cd48450da3e787afeead8732cc013bd7acb9870626
+82764f70656e4944345650444341504948616e646f7665725820fbece366f4212f9762c74cfdbf83b8c69e371d5d68cea09cb4c48ca6daab761a
 
 CBOR diagnostic:
 
@@ -2400,15 +2400,15 @@ CBOR diagnostic:
   76                                              #   string(22)
     4f70656e4944345650444341504948616e646f766572  #     "OpenID4VPDCAPIHandover"
   58 20                                           #   bytes(32)
-    3f94de36e3292c1ded4511cd48450da3e787afeead87  #     "?\x94Þ6ã),\x1díE\x11ÍHE\x0d£ç\x87¯î\xad\x87"
-    32cc013bd7acb9870626                          #     "2Ì\x01;×¬¹\x87\x06&"
+    fbece366f4212f9762c74cfdbf83b8c69e371d5d68ce  #     "ûìãfô!/\x97bÇLý¿\x83¸Æ\x9e7\x1d]hÎ"
+    a09cb4c48ca6daab761a                          #     "\xa0\x9c´Ä\x8c¦Ú«v\x1a"
 ```
 
 The following is a non-normative example of the `SessionTranscript` structure:
 ```
 Hex:
 
-83f6f682764f70656e4944345650444341504948616e646f76657258203f94de36e3292c1ded4511cd48450da3e787afeead8732cc013bd7acb9870626
+83f6f682764f70656e4944345650444341504948616e646f7665725820fbece366f4212f9762c74cfdbf83b8c69e371d5d68cea09cb4c48ca6daab761a
 
 CBOR diagnostic:
 
@@ -2420,8 +2420,8 @@ CBOR diagnostic:
       4f70656e4944345650444341504948616e646f7665  #       "OpenID4VPDCAPIHandove"
       72                                          #       "r"
     58 20                                         #     bytes(32)
-      3f94de36e3292c1ded4511cd48450da3e787afeead  #       "?\x94Þ6ã),\x1díE\x11ÍHE\x0d£ç\x87¯î\xad"
-      8732cc013bd7acb9870626                      #       "\x872Ì\x01;×¬¹\x87\x06&"
+      fbece366f4212f9762c74cfdbf83b8c69e371d5d68  #       "ûìãfô!/\x97bÇLý¿\x83¸Æ\x9e7\x1d]h"
+      cea09cb4c48ca6daab761a                      #       "Î\xa0\x9c´Ä\x8c¦Ú«v\x1a"
 ```
 
 #### Invocation via other methods {#non-dc-api-invocation}

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2356,6 +2356,61 @@ The `OpenID4VPDCAPIHandover` structure has the following elements:
   * The second element MUST be the value of the effective Client Identifier as defined in (#dc_api_request).
   * The third element MUST be the value of the `nonce` request parameter.
 
+The following is a non-normative example of the `OpenID4VPDCAPIHandoverInfo` structure:
+```
+Hex:
+
+837368747470733a2f2f6578616d706c652e636f6d781e7765622d6f726967696e3a68747470733a2f2f6578616d706c652e636f6d782b313141457a39684f5375354c5f666f43474a776c5765454c6f525458636433627a6a5350725a376956446b
+
+CBOR diagnostic:
+
+83                                                # array(3)
+  73                                              #   string(19)
+    68747470733a2f2f6578616d706c652e636f6d        #     "https://example.com"
+  78 1e                                           #   string(30)
+    7765622d6f726967696e3a68747470733a2f2f657861  #     "web-origin:https://exa"
+    6d706c652e636f6d                              #     "mple.com"
+  78 2b                                           #   string(43)
+    313141457a39684f5375354c5f666f43474a776c5765  #     "11AEz9hOSu5L_foCGJwlWe"
+    454c6f525458636433627a6a5350725a376956446b    #     "ELoRTXcd3bzjSPrZ7iVDk"
+```
+
+The following is a non-normative example of the `OpenID4VPDCAPIHandover` structure:
+```
+Hex:
+
+82764f70656e4944345650444341504948616e646f7665725820507ee40d57b7d0c4f82d7c7e140a4b2d44753970d085729ea1f2cfa98243b08f
+
+CBOR diagnostic:
+
+82                                                # array(2)
+  76                                              #   string(22)
+    4f70656e4944345650444341504948616e646f766572  #     "OpenID4VPDCAPIHandover"
+  58 20                                           #   bytes(32)
+    507ee40d57b7d0c4f82d7c7e140a4b2d44753970d085  #     "P~ä\x0dW·ÐÄø-|~\x14\x0aK-Du9pÐ\x85"
+    729ea1f2cfa98243b08f                          #     "r\x9e¡òÏ©\x82C°\x8f"
+```
+
+The following is a non-normative example of the `SessionTranscript` structure:
+```
+Hex:
+
+83f6f682764f70656e4944345650444341504948616e646f7665725820507ee40d57b7d0c4f82d7c7e140a4b2d44753970d085729ea1f2cfa98243b08f
+
+CBOR diagnostic:
+
+83                                                # array(3)
+  f6                                              #   null
+  f6                                              #   null
+  82                                              #   array(2)
+    76                                            #     string(22)
+      4f70656e4944345650444341504948616e646f7665  #       "OpenID4VPDCAPIHandove"
+      72                                          #       "r"
+    58 20                                         #     bytes(32)
+      507ee40d57b7d0c4f82d7c7e140a4b2d44753970d0  #       "P~ä\x0dW·ÐÄø-|~\x14\x0aK-Du9pÐ"
+      85729ea1f2cfa98243b08f                      #       "\x85r\x9e¡òÏ©\x82C°\x8f"
+```
+
 #### Invocation via other methods {#non-dc-api-invocation}
 
 If the presentation request is invoked via other methods, the rules for generating the `SessionTranscript` and `Handover` CBOR structure are specified in ISO/IEC 18013-7 [@ISO.18013-7], ISO/IEC 18013-5 [@ISO.18013-5] and ISO/IEC 23220-4 [@ISO.23220-4].

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2373,55 +2373,65 @@ The following is a non-normative example of the `OpenID4VPDCAPIHandoverInfo` str
 ```
 Hex:
 
-837368747470733a2f2f6578616d706c652e636f6d782b6578633767426b786a7831726463397564527276654b7653734a4971383061766c58654c4868477771744158204283ec927ae0f208daaa2d026a814f2b22dca52cf85ffa8f3f8626c6bd669047
+837368747470733a2f2f6578616d706c652e636f6d782b6578633767426b786a7831
+726463397564527276654b7653734a4971383061766c58654c486847777174415820
+4283ec927ae0f208daaa2d026a814f2b22dca52cf85ffa8f3f8626c6bd669047
 
 CBOR diagnostic:
 
-83                                                # array(3)
-  73                                              #   string(19)
-    68747470733a2f2f6578616d706c652e636f6d        #     "https://example.com"
-  78 2b                                           #   string(43)
-    6578633767426b786a7831726463397564527276654b  #     "exc7gBkxjx1rdc9udRrveK"
-    7653734a4971383061766c58654c48684777717441    #     "vSsJIq80avlXeLHhGwqtA"
-  58 20                                           #   bytes(32)
-    4283ec927ae0f208daaa2d026a814f2b22dca52cf85f  #     "B\x83ì\x92zàò\x08Úª-\x02j\x81O+"Ü¥,ø_"
-    fa8f3f8626c6bd669047                          #     "ú\x8f?\x86&Æ½f\x90G"
+83                                 # array(3)
+  73                               #   string(19)
+    68747470733a2f2f6578616d706c65 #     "https://example"
+    2e636f6d                       #     ".com"
+  78 2b                            #   string(43)
+    6578633767426b786a783172646339 #     "exc7gBkxjx1rdc9"
+    7564527276654b7653734a49713830 #     "udRrveKvSsJIq80"
+    61766c58654c48684777717441     #     "avlXeLHhGwqtA"
+  58 20                            #   bytes(32)
+    4283ec927ae0f208daaa2d026a814f #     "B\x83ì\x92zàò\x08Úª-\x02j\x81O"
+    2b22dca52cf85ffa8f3f8626c6bd66 #     "+"Ü¥,ø_ú\x8f?\x86&Æ½f"
+    9047                           #     "\x90G"
 ```
 
 The following is a non-normative example of the `OpenID4VPDCAPIHandover` structure:
 ```
 Hex:
 
-82764f70656e4944345650444341504948616e646f7665725820fbece366f4212f9762c74cfdbf83b8c69e371d5d68cea09cb4c48ca6daab761a
+82764f70656e4944345650444341504948616e646f7665725820fbece366f4212f97
+62c74cfdbf83b8c69e371d5d68cea09cb4c48ca6daab761a
 
 CBOR diagnostic:
 
-82                                                # array(2)
-  76                                              #   string(22)
-    4f70656e4944345650444341504948616e646f766572  #     "OpenID4VPDCAPIHandover"
-  58 20                                           #   bytes(32)
-    fbece366f4212f9762c74cfdbf83b8c69e371d5d68ce  #     "ûìãfô!/\x97bÇLý¿\x83¸Æ\x9e7\x1d]hÎ"
-    a09cb4c48ca6daab761a                          #     "\xa0\x9c´Ä\x8c¦Ú«v\x1a"
+82                                 # array(2)
+  76                               #   string(22)
+    4f70656e4944345650444341504948 #     "OpenID4VPDCAPIH"
+    616e646f766572                 #     "andover"
+  58 20                            #   bytes(32)
+    fbece366f4212f9762c74cfdbf83b8 #     "ûìãfô!/\x97bÇLý¿\x83¸"
+    c69e371d5d68cea09cb4c48ca6daab #     "Æ\x9e7\x1d]hÎ\xa0\x9c´Ä\x8c¦Ú«"
+    761a                           #     "v\x1a"
 ```
 
 The following is a non-normative example of the `SessionTranscript` structure:
 ```
 Hex:
 
-83f6f682764f70656e4944345650444341504948616e646f7665725820fbece366f4212f9762c74cfdbf83b8c69e371d5d68cea09cb4c48ca6daab761a
+83f6f682764f70656e4944345650444341504948616e646f7665725820fbece366f4
+212f9762c74cfdbf83b8c69e371d5d68cea09cb4c48ca6daab761a
 
 CBOR diagnostic:
 
-83                                                # array(3)
-  f6                                              #   null
-  f6                                              #   null
-  82                                              #   array(2)
-    76                                            #     string(22)
-      4f70656e4944345650444341504948616e646f7665  #       "OpenID4VPDCAPIHandove"
-      72                                          #       "r"
-    58 20                                         #     bytes(32)
-      fbece366f4212f9762c74cfdbf83b8c69e371d5d68  #       "ûìãfô!/\x97bÇLý¿\x83¸Æ\x9e7\x1d]h"
-      cea09cb4c48ca6daab761a                      #       "Î\xa0\x9c´Ä\x8c¦Ú«v\x1a"
+83                                 # array(3)
+  f6                               #   null
+  f6                               #   null
+  82                               #   array(2)
+    76                             #     string(22)
+      4f70656e49443456504443415049 #       "OpenID4VPDCAPI"
+      48616e646f766572             #       "Handover"
+    58 20                          #     bytes(32)
+      fbece366f4212f9762c74cfdbf83 #       "ûìãfô!/\x97bÇLý¿\x83"
+      b8c69e371d5d68cea09cb4c48ca6 #       "¸Æ\x9e7\x1d]hÎ\xa0\x9c´Ä\x8c¦"
+      daab761a                     #       "Ú«v\x1a"
 ```
 
 #### Invocation via other methods {#non-dc-api-invocation}

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2356,6 +2356,19 @@ The `OpenID4VPDCAPIHandover` structure has the following elements:
   * The second element MUST be the value of the effective Client Identifier as defined in (#dc_api_request).
   * The third element MUST be the value of the `nonce` request parameter.
 
+The following is a non-normative example of the input JWK for the JWK Thumbprint for the `OpenID4VPDCAPIHandoverInfo`:
+```json
+{
+  "kty": "EC",
+  "crv": "P-256",
+  "x": "DxiH5Q4Yx3UrukE2lWCErq8N8bqC9CHLLrAwLz5BmE0",
+  "y": "XtLM4-3h5o3HUH0MHVJV0kyq0iBlrBwlh8qEDMZ4-Pc",
+  "use": "enc",
+  "alg": "ECDH-ES",
+  "kid": "1"
+}
+```
+
 The following is a non-normative example of the `OpenID4VPDCAPIHandoverInfo` structure:
 ```
 Hex:


### PR DESCRIPTION
Depends on
- https://github.com/openid/OpenID4VP/pull/470 (inclusion of `jwk_thumbprint` in `SessionTranscript`)
- https://github.com/openid/OpenID4VP/pull/448 (removal of `client_id` from `SessionTranscript`)

This PR is non-normative and just provides an example for `SessionTranscript`-related objects specific for DC API.

Fixes #425
