### PR TITLE
slight tweak to default treatment of https URLs

### DIFF
--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -528,7 +528,7 @@ If a `:` character is not present in the Client Identifier, the Wallet MUST trea
 
 For example, if an Authorization Request contains `client_id=example-client`, the Wallet would interpret the Client Identifier as referring to a pre-registered client.
 
-If the Client Identifier begins with `https://`, the Wallet MUST treat the Client Identifier as an Entity Identifier defined in OpenID Federation [@!OpenID.Federation].
+If the Client Identifier begins with `https://` the full Client Identifier URL represents an Entity Identifier defined in OpenID Federation [@!OpenID.Federation] and MUST be processed as though it was prefixed with `openid_federation` as described below.
 
 If a `:` character is present in the Client Identifier but the value preceding it is not a recognized and supported Client Identifier Scheme value, the Wallet MAY treat the Client Identifier as having a default Client Identifier Scheme. 
 
@@ -584,9 +584,7 @@ Body
 
 * `openid_federation`: This value indicates that the Client Identifier is an Entity Identifier defined in OpenID Federation [@!OpenID.Federation]. Processing rules given in [@!OpenID.Federation] MUST be followed. Automatic Registration as defined in [@!OpenID.Federation] MUST be used. The Authorization Request MAY also contain a `trust_chain` parameter. The final Verifier metadata is obtained from the Trust Chain after applying the policies, according to [@!OpenID.Federation]. The `client_metadata` parameter, if present in the Authorization Request, MUST be ignored when this Client Identifier scheme is used. Example Client Identifier: `openid_federation:https://federation-verifier.example.com`.
 
-* `https`: If the Client Identifier begins with `https://` (the Client Identifier Scheme being `https`) the full Client Identifier URL represents an Entity Identifier defined in OpenID Federation [@!OpenID.Federation] and MUST be processed as though it was prefixed with `openid_federation` as described above. Example Client Identifier: `https://federation-verifier.example.com`.
-
-To use the Client Identifier Schemes `openid_federation`, `https`, `decentralized_identifier`, `verifier_attestation`, `x509_san_dns` and `x509_hash`, Verifiers MUST be confidential clients. This might require changes to the technical design of native apps as such apps are typically public clients.
+To use the Client Identifier Schemes `openid_federation`, `decentralized_identifier`, `verifier_attestation`, `x509_san_dns` and `x509_hash`, Verifiers MUST be confidential clients. This might require changes to the technical design of native apps as such apps are typically public clients.
 
 Other specifications can define further Client Identifier Schemes. It is RECOMMENDED to use collision-resistant names for such values.
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -529,6 +529,7 @@ If a `:` character is not present in the Client Identifier, the Wallet MUST trea
 For example, if an Authorization Request contains `client_id=example-client`, the Wallet would interpret the Client Identifier as referring to a pre-registered client.
 
 If the Client Identifier begins with `https://` the full Client Identifier URL represents an Entity Identifier defined in OpenID Federation [@!OpenID.Federation] and MUST be processed as though it was prefixed with `openid_federation` as described below.
+Note that like all requirements in this specification, this requirement only applies when using this specification.
 
 If a `:` character is present in the Client Identifier but the value preceding it is not a recognized and supported Client Identifier Scheme value, the Wallet MAY treat the Client Identifier as having a default Client Identifier Scheme. 
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -528,11 +528,13 @@ If a `:` character is not present in the Client Identifier, the Wallet MUST trea
 
 For example, if an Authorization Request contains `client_id=example-client`, the Wallet would interpret the Client Identifier as referring to a pre-registered client.
 
+If the Client Identifier begins with `https://`, the Wallet MUST treat the Client Identifier as an Entity Identifier defined in OpenID Federation [@!OpenID.Federation].
+
 If a `:` character is present in the Client Identifier but the value preceding it is not a recognized and supported Client Identifier Scheme value, the Wallet MAY treat the Client Identifier as having a default Client Identifier Scheme. 
 
-For example, an Authorization Request containing a `client_id` value of `https://federation-verifier.example.com` could be interpreted by the Wallet as referring to an OpenID Federation Entity Identifier, with the default Client Identifier Scheme being `openid_federation`.
+For example, an Authorization Request containing a `client_id` value of `https://federation-verifier.example.com` would be interpreted by the Wallet as referring to an OpenID Federation Entity Identifier.
 
-From this definition, it follows that pre-registered clients MUST NOT contain a `:` character preceded immediately by a supported Client Identifier Scheme value in the first part of their Client Identifier.
+From this definition, it follows that pre-registered clients MUST NOT contain a `:` character preceded immediately by a supported Client Identifier Scheme value or `https` in the first part of their Client Identifier.
 
 ### Security Considerations
 
@@ -560,8 +562,6 @@ Location: https://wallet.example.org/universal-link?
     7D%7D%7D
 ```
 
-* `openid_federation`: This value indicates that the Client Identifier is an Entity Identifier defined in OpenID Federation [@!OpenID.Federation]. Processing rules given in [@!OpenID.Federation] MUST be followed. Automatic Registration as defined in [@!OpenID.Federation] MUST be used. The Authorization Request MAY also contain a `trust_chain` parameter. The final Verifier metadata is obtained from the Trust Chain after applying the policies, according to [@!OpenID.Federation]. The `client_metadata` parameter, if present in the Authorization Request, MUST be ignored when this Client Identifier scheme is used. Example Client Identifier: `openid_federation:https://federation-verifier.example.com`.
-
 * `decentralized_identifier`: This value indicates that the Client Identifier is a DID defined in [@!DID-Core]. The request MUST be signed with a private key associated with the DID. A public key to verify the signature MUST be obtained from the `verificationMethod` property of a DID Document. Since DID Document may include multiple public keys, a particular public key used to sign the request in question MUST be identified by the `kid` in the JOSE Header. To obtain the DID Document, the Wallet MUST use DID Resolution defined by the DID method used by the Verifier. All Verifier metadata other than the public key MUST be obtained from the `client_metadata` parameter as defined in (#new_parameters). Example Client Identifier: `decentralized_identifier:did:example:123`.
 
 The following is a non-normative example of a header and a body of a signed Request Object when the Client Identifier scheme is `decentralized_identifier`:
@@ -582,7 +582,11 @@ Body
 
 * `x509_hash`: When the Client Identifier Scheme is `x509_hash`, the Client Identifier MUST be a hash and match the hash of the leaf certificate passed with the request. The request MUST be signed with the private key corresponding to the public key in the leaf X.509 certificate of the certificate chain added to the request in the `x5c` JOSE header parameter [@!RFC7515] of the signed request object. The value of `x509_hash` is the base64url encoded value of the SHA-256 hash of the DER-encoded X.509 certificate. The Wallet MUST validate the signature and the trust chain of the X.509 leaf certificate. All verifier metadata other than the public key MUST be obtained from the `client_metadata` parameter. Example Client Identifier: `x509_hash:Uvo3HtuIxuhC92rShpgqcT3YXwrqRxWEviRiA0OZszk`
 
-To use the Client Identifier Schemes `https`, `did`, `verifier_attestation`, `x509_san_dns` and `x509_hash`, Verifiers MUST be confidential clients. This might require changes to the technical design of native apps as such apps are typically public clients.
+* `openid_federation`: This value indicates that the Client Identifier is an Entity Identifier defined in OpenID Federation [@!OpenID.Federation]. Processing rules given in [@!OpenID.Federation] MUST be followed. Automatic Registration as defined in [@!OpenID.Federation] MUST be used. The Authorization Request MAY also contain a `trust_chain` parameter. The final Verifier metadata is obtained from the Trust Chain after applying the policies, according to [@!OpenID.Federation]. The `client_metadata` parameter, if present in the Authorization Request, MUST be ignored when this Client Identifier scheme is used. Example Client Identifier: `openid_federation:https://federation-verifier.example.com`.
+
+* `https`: If the Client Identifier begins with `https://` (the Client Identifier Scheme being `https`) the full Client Identifier URL represents an Entity Identifier defined in OpenID Federation [@!OpenID.Federation] and MUST be processed as though it was prefixed with `openid_federation` as described above. Example Client Identifier: `https://federation-verifier.example.com`.
+
+To use the Client Identifier Schemes `openid_federation`, `https`, `decentralized_identifier`, `verifier_attestation`, `x509_san_dns` and `x509_hash`, Verifiers MUST be confidential clients. This might require changes to the technical design of native apps as such apps are typically public clients.
 
 Other specifications can define further Client Identifier Schemes. It is RECOMMENDED to use collision-resistant names for such values.
 


### PR DESCRIPTION
unambiguously defines the plain https Client Identifier URLs as a fallback to mean OpenID Federation

This is a PR against the open PR #401 

Context of this PR is documented in https://github.com/openid/OpenID4VP/pull/401#issuecomment-2747041478