### PR TITLE
editorial: fixed DC API response modes in examples

### DIFF
--- a/examples/digital_credentials_api/signed_request_payload.json
+++ b/examples/digital_credentials_api/signed_request_payload.json
@@ -4,7 +4,7 @@
     "https://origin2.example.com"
   ],
   "response_type": "vp_token",
-  "response_mode": "dc_api.jwt",
+  "response_mode": "dc_api",
   "nonce": "n-0S6_WzA2Mj",
   "dcql_query": {...},
   "client_metadata": {

--- a/examples/digital_credentials_api/signed_request_payload_compact.json
+++ b/examples/digital_credentials_api/signed_request_payload_compact.json
@@ -19,7 +19,7 @@
     }
   },
   "response_type": "vp_token",
-  "response_mode": "w3c_dc_api.jwt",
+  "response_mode": "dc_api",
   "nonce": "n-0S6_WzA2Mj",
   "dcql_query": {...}
 }


### PR DESCRIPTION
This PR fixes the response modes for DC API, it also uses dc_api (without .jwt) to make it clear that .jwt is not needed if all you need is signed requests.