### PR TITLE
Update Digital Credentials API reference link (post WG migration)

### DIFF
--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2099,7 +2099,7 @@ Ecosystems that plan to leverage the trusted authorities mechanisms SHOULD make 
         </front>
 </reference>
 
-<reference anchor="W3C.Digital_Credentials_API" target="https://wicg.github.io/digital-credentials/">
+<reference anchor="W3C.Digital_Credentials_API" target="https://w3c-fedid.github.io/digital-credentials/">
         <front>
           <title>Digital Credentials API</title>
 		  <author fullname="Marcos Caceres">


### PR DESCRIPTION
After migration from the WICG to the Federated ID WG at W3C, the original WICG link broke. This updates the reference to point to the new WG repo's preview link.

This link will change again (to a stable one) once we cut a first public working draft in a few weeks.