### PR TITLE
clarify that client identifier prefix specific parameters got to the header in multi RP DC API requests

### DIFF
--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2283,6 +2283,7 @@ In this case, the following request parameters MUST be present in the protected 
 
 * `client_id`
 * `verifier_attestations`
+* parameters that are specific to the Client Identifier Prefix used, e.g., `trust_chain` JWS header parameter for `openid_federation:` Client Identifier Prefix 
 
 All other request parameters MUST be present in the `payload` element of the JWS object.
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -3089,6 +3089,7 @@ The technology described in this specification was made available from contribut
    -27
 
    * remove AnonCreds for now as we're lacking implementation experience
+   * clarify that client identifier prefix specific parameters got to the header in multi RP DC API requests 
 
    -26
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2283,7 +2283,7 @@ In this case, the following request parameters MUST be present in the protected 
 
 * `client_id`
 * `verifier_attestations`
-* parameters that are specific to the Client Identifier Prefix used, e.g., `trust_chain` JWS header parameter for `openid_federation:` Client Identifier Prefix 
+* parameters that are specific to a Client Identifier Prefix, e.g., the `trust_chain` JWS header parameter for the `openid_federation` Client Identifier Prefix 
 
 All other request parameters MUST be present in the `payload` element of the JWS object.
 


### PR DESCRIPTION
resolves #510 

(meant to mark this PR draft before WG discussion and forgot.. sorry about that..)