### PR TITLE
Remove whitespace in document history

### DIFF
--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -3165,7 +3165,7 @@ The technology described in this specification was made available from contribut
 
    * clarify value matching in DCQL
    * clarify why requests using redirect_uri scheme cannot be signed
-   * add `trusted_authorities` to DCQL  
+   * add `trusted_authorities` to DCQL
    * add note introducing cbor and cddl
    * clarify DCQL case of `claims` and `claim_sets` being absent
    * add language on client ID and nonce binding for ISO mdocs and W3C VCs


### PR DESCRIPTION
Just a small change, but it triggers my eye every time I scroll by the change log

![img](https://github.com/user-attachments/assets/65eb58dd-bdd1-4a95-8891-a95d5bc47164)
