### PR TITLE
Issue 457 transaction data hashes

### DIFF
--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -1201,6 +1201,8 @@ The Response Mode is defined in accordance with [@!OAuth.Responses] as follows:
 
 The following new Authorization Request parameter is defined to be used in conjunction with Response Mode `direct_post`: 
 
+If the Response Endpoint receives a request in the direct_post response mode that is structurally valid and complies with the submission requirements of the presentation definition, it MUST respond with an HTTP status code 200, indicating that the request was successfully processed in terms of protocol compliance. If the submitted credential is invalid (e.g., expired, revoked, or does not meet the verifier’s functional requirements), the Response Endpoint SHOULD respond with an HTTP status code 400 (Bad Request). The 400 response MUST include an `error` parameter with a value such as `invalid_credential` or `functional_requirements_not_met`, and MAY include a `redirect_uri` to allow the wallet to resubmit with different credentials. The `error_description` parameter MAY provide additional details to assist the wallet in correcting the submission.
+
 `response_uri`:
 : REQUIRED when the Response Mode `direct_post` is used. The URL to which the Wallet MUST send the Authorization Response using an HTTP POST request as defined by the Response Mode `direct_post`. The Response URI receives all Authorization Response parameters as defined by the respective Response Type. When the `response_uri` parameter is present, the `redirect_uri` Authorization Request parameter MUST NOT be present. If the `redirect_uri` Authorization Request parameter is present when the Response Mode is `direct_post`, the Wallet MUST return an `invalid_request` Authorization Response error. The `response_uri` value MUST be a value that the client would be permitted to use as `redirect_uri` when following the rules defined in (#client_metadata_management).
 
@@ -1257,6 +1259,7 @@ Content-Type: application/x-www-form-urlencoded
 ```
 
 If the Response URI has successfully processed the Authorization Response or Authorization Error Response, it MUST respond with an HTTP status code of 200 with `Content-Type` of `application/json` and a JSON object in the response body.
+
 
 The following new parameter is defined for use in the JSON object returned from the Response Endpoint to the Wallet:
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -1299,7 +1299,7 @@ This section defines how an Authorization Response containing a VP Token (such a
 To encrypt the Authorization Response, implementations MUST use an unsigned, encrypted JWT as described in [@!RFC7519].
 
 To obtain the Verifier's public key to which to encrypt the Authorization Response, the Wallet uses keys from client metadata, such as the `jwks` member within the `client_metadata` request parameter, the metadata defined in the Entity Configuration if OpenID Federation is used, or other mechanisms.
-Using what it supports and its ps, the Wallet selects the public key to encrypt the Authorization Response based on information about each key, such as the `kty` (Key Type), `use` (Public Key Use), `alg` (Algorithm), and other JWK parameters. 
+Using what it supports and its preferences, the Wallet selects the public key to encrypt the Authorization Response based on information about each key, such as the `kty` (Key Type), `use` (Public Key Use), `alg` (Algorithm), and other JWK parameters. 
 The `alg` parameter MUST be present in the JWKs.
 The JWE `alg` algorithm used MUST be equal to the `alg` value of the chosen `jwk`.
 If the selected public key contains a `kid` parameter, the JWE MUST include the same value in the `kid` JWE Header Parameter (as defined in [@!RFC7516, Section 4.1.6]) of the encrypted response. This enables the Verifier to easily identify the specific public key that was used to encrypt the response.

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2945,7 +2945,6 @@ Given a `transaction_data` array:
 [
   "eyJ0eXBlIjoicGF5bWVudCIsImNyZWRlbnRpYWxfaWRzIjpbIjEyMyJdLCJhbW91bnQiOjEwMC4wMH0"
 ]
-
 {
   "transaction_data_hashes": [
     "1RfsZ1oRryNj3uUHOsQe2sx3_YG04pM0rW93w4q2p8M"


### PR DESCRIPTION
This PR resolves issue #457 by updating the `transaction_data_hashes` definition in Appendix B.3.1.0 (SD-JWT Profile) to specify that each hash is a base64url-encoded SHA-256 hash of the UTF-8 JSON data obtained by base64url-decoding each `transaction_data` element, per @sander’s proposal. A non-normative example demonstrates the decoding, hashing, and encoding steps. The text addresses @ubamrein’s concerns by requiring valid UTF-8 decoding to prevent errors, ensuring interoperability.