### PR TITLE
Update non-final specs

### DIFF
--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -1742,6 +1742,7 @@ Implementers should be aware that this specification uses several specifications
 
 * OpenID Federation 1.0 draft -42 [@!OpenID.Federation]
 * SIOPv2 draft -13 [@!SIOPv2]
+* Selective Disclosure for JWTs (SD-JWT) draft -22 [@!I-D.ietf-oauth-selective-disclosure-jwt]
 * SD-JWT-based Verifiable Credentials (SD-JWT VC) draft -09 [@!I-D.ietf-oauth-sd-jwt-vc]
 * Fully-Specified Algorithms for JOSE and COSE draft -13 [@!I-D.ietf-jose-fully-specified-algorithms]
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -1740,9 +1740,10 @@ Note: If the Verifier's Response URI did not return a `redirect_uri` in step (6)
 
 Implementers should be aware that this specification uses several specifications that are not yet final specifications. Those specifications are:
 
-- OpenID Federation 1.0 draft -42 [@!OpenID.Federation]
-- SIOPv2 draft -13 [@!SIOPv2]
-- SD-JWT-based Verifiable Credentials (SD-JWT VC) draft -08 [@!I-D.ietf-oauth-sd-jwt-vc]
+* OpenID Federation 1.0 draft -42 [@!OpenID.Federation]
+* SIOPv2 draft -13 [@!SIOPv2]
+* SD-JWT-based Verifiable Credentials (SD-JWT VC) draft -09 [@!I-D.ietf-oauth-sd-jwt-vc]
+* Fully-Specified Algorithms for JOSE and COSE draft -13 [@!I-D.ietf-jose-fully-specified-algorithms]
 
 While breaking changes to the specifications referenced in this specification are not expected, should they occur, OpenID4VP implementations should continue to use the specifically referenced versions above in preference to the final versions, unless updated by a profile or new version of this specification.
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -3346,6 +3346,7 @@ The technology described in this specification was made available from contribut
 
    -29
 
+   * update pre-final specs section
    * make the `meta` parameter mandatory in DCQL query
    * explicitly state that various arrays need to be non-empty
 


### PR DESCRIPTION
Closes #530

Added Fully-specified Algorithms and updated references.

I went through the normative references and we currently have 2 other specs not mentioned here:
- SD-JWT which I think is fine since it is implied by sd-jwt vc and is getting published soon?
- DC API which is intentional as far as I understand and the section is written in a way that we do not normatively depend on the concrete constructions inside that reference?