### PR TITLE
Security Checks on the DCQL Query

### DIFF
--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -1898,6 +1898,10 @@ these constraints. The Wallet is not controlled by the Verifier and the Verifier
 MUST perform its own security checks on the returned Credentials and
 Presentations.
 
+## Security Checks on the DCQL Query {#dcql_injection}
+
+Recipients of DCQL query MUST treat the incoming query as untrusted input. A malformed or malicious statement could trigger a "DCQL injection" altering the normal processing. Implementations MUST NOT rely on the Verifier for sanitation; they MUST independently validate query syntax, semantics, permitted scopes, resource identifiers, and execution context before acceptance or evaluation.
+
 # Privacy Considerations {#privacy-considerations}
 
 Many privacy considerations are specific to the Credential format and associated proof type used in a particular Presentation.


### PR DESCRIPTION
During the security analysis of the Digital Credentials API, we identified an issue with using a query language in protocols.
 
The use of a query language such as DCQL generates a potential vulnerability in terms of injection, as defined by [CWE-943](https://cwe.mitre.org/data/definitions/943.html):

> The product generates a query intended to access or manipulate data in a data store such as a database, but it does not neutralize or incorrectly neutralizes special elements that can modify the intended logic of the query

It is therefore important to indicate in the Security Considerations section or warn the issue to the implementers.

Thanks,

Simone