### PR TITLE
Update Digital Credentials API reference to FPWD

### DIFF
--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2287,6 +2287,7 @@ Ecosystems intending to use trusted authority mechanisms SHOULD ensure that the 
           <author fullname="Mohamed Amir Yosef">
             <organization>Google</organization>
           </author>
+          <date day="1" month="July" year="2025"/>
         </front>
 </reference>
 

--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -2275,7 +2275,7 @@ Ecosystems intending to use trusted authority mechanisms SHOULD ensure that the 
         </front>
 </reference>
 
-<reference anchor="W3C.Digital_Credentials_API" target="https://w3c-fedid.github.io/digital-credentials/">
+<reference anchor="W3C.Digital_Credentials_API" target="https://www.w3.org/TR/2025/WD-digital-credentials-20250701/">
         <front>
           <title>Digital Credentials API</title>
 		  <author fullname="Marcos Caceres">
@@ -2284,7 +2284,7 @@ Ecosystems intending to use trusted authority mechanisms SHOULD ensure that the 
           <author fullname="Tim Cappalli">
             <organization>Okta</organization>
           </author>
-          <author fullname="Sam Goto">
+          <author fullname="Mohamed Amir Yosef">
             <organization>Google</organization>
           </author>
         </front>


### PR DESCRIPTION
Update W3C Digital Credentials API reference from a non-stable version to the stable link to the [First Public Working Draft](https://www.w3.org/TR/2025/WD-digital-credentials-20250701/) 🎉