### PR TITLE
Add 1.0 to document title

### DIFF
--- a/openid-4-verifiable-presentations-1_0.md
+++ b/openid-4-verifiable-presentations-1_0.md
@@ -1631,7 +1631,7 @@ This section lists profiles of this specification that define static configurati
 
 The following is a list of profiles that define static configuration values of Wallets:
 
-- [OpenID4VC High Assurance Interoperability Profile](https://openid.net/specs/openid4vc-high-assurance-interoperability-profile-1_0.html)
+- [OpenID4VC High Assurance Interoperability Profile 1.0](https://openid.net/specs/openid4vc-high-assurance-interoperability-profile-1_0.html)
 - [JWT VC Presentation Profile](https://identity.foundation/jwt-vc-presentation-profile/)
 
 ### A Set of Static Configuration Values bound to `openid4vp://` {#openid4vp-scheme}
@@ -2115,11 +2115,11 @@ Ecosystems intending to use trusted authority mechanisms SHOULD ensure that the 
 
 <reference anchor="OpenID4VCI" target="https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html">
   <front>
-    <title>OpenID for Verifiable Credential Issuance - draft 15</title>
+    <title>OpenID for Verifiable Credential Issuance 1.0 - draft 16</title>
     <author fullname="Torsten Lodderstedt"/>
     <author fullname="Kristina Yasuda"/>
     <author fullname="Tobias Looker"/>
-    <date day="19" month="December" year="2024"/>
+    <date day="26" month="June" year="2025"/>
   </front>
 </reference>
 


### PR DESCRIPTION
Many (but not all) OIDF specs have version numbers in the title; given we are likely to have 1.1 etc versions of OID4VP it seems good to give the version number a bit more prominence.