### PR TITLE
`aud` must match `issuer` metadata in dynamic discovery

### DIFF
--- a/1.0/openid-4-verifiable-presentations-1_0.md
+++ b/1.0/openid-4-verifiable-presentations-1_0.md
@@ -532,7 +532,7 @@ The usage of the Response Mode `direct_post` (see (#response_mode_post)) in conj
 
 When the Verifier is sending a Request Object as defined in [@!RFC9101], the `aud` claim value depends on whether the recipient of the request can be identified by the Verifier or not:
 
-- the `aud` claim MUST be equal to the `iss` (issuer) claim value, when Dynamic Discovery is performed.
+- the `aud` claim MUST be equal to the `issuer` parameter in the Wallet Metadata, when Dynamic Discovery is performed.
 - the `aud` claim MUST be "https://self-issued.me/v2", when Static Discovery metadata is used.
 
 Note: "https://self-issued.me/v2" is a symbolic string and can be used as an `aud` claim value even when this specification is used standalone, without SIOPv2.
@@ -3567,6 +3567,7 @@ The technology described in this specification was made available from contribut
 -31
 
    * Clarify that `encrypted_response_enc_values_supported` applies only if JWE content encryption algorithm is used
+   * Clarify that `aud` corresponds to `issuer` Wallet Metadata paremeter if Dynamic Discovery is used 
    
 -final
    

--- a/1.1/openid-4-verifiable-presentations-1_1.md
+++ b/1.1/openid-4-verifiable-presentations-1_1.md
@@ -528,7 +528,7 @@ The usage of the Response Mode `direct_post` (see (#response_mode_post)) in conj
 
 When the Verifier is sending a Request Object as defined in [@!RFC9101], the `aud` claim value depends on whether the recipient of the request can be identified by the Verifier or not:
 
-- the `aud` claim MUST be equal to the `iss` (issuer) claim value, when Dynamic Discovery is performed.
+- the `aud` claim MUST be equal to the `issuer` parameter in the Wallet Metadata, when Dynamic Discovery is performed.
 - the `aud` claim MUST be "https://self-issued.me/v2", when Static Discovery metadata is used.
 
 Note: "https://self-issued.me/v2" is a symbolic string and can be used as an `aud` claim value even when this specification is used standalone, without SIOPv2.
@@ -3569,3 +3569,4 @@ The technology described in this specification was made available from contribut
 
    * Add security consideration not to use VP Token as Access Token
    * Clarify that `encrypted_response_enc_values_supported` applies only if JWE content encryption algorithm is used; e.g., it does not apply to JOSE HPKE
+   * Clarify that `aud` corresponds to `issuer` Wallet Metadata paremeter if Dynamic Discovery is used


### PR DESCRIPTION
Fixes #714 