### PR TITLE
examples for client_metadata.jwks all include 'use' in the key but it's not required by spec

### DIFF
--- a/1.0/examples/digital_credentials_api/signed_request_payload_compact.json
+++ b/1.0/examples/digital_credentials_api/signed_request_payload_compact.json
@@ -12,7 +12,6 @@
           "crv": "P-256",
           "x": "MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",
           "y": "4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM",
-          "use": "enc",
           "kid": "1"
         }
       ]

--- a/1.1/examples/digital_credentials_api/signed_request_payload_compact.json
+++ b/1.1/examples/digital_credentials_api/signed_request_payload_compact.json
@@ -12,7 +12,6 @@
           "crv": "P-256",
           "x": "MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",
           "y": "4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM",
-          "use": "enc",
           "kid": "1"
         }
       ]


### PR DESCRIPTION
fixes #711 by removing use from one of the examples
i was not able to find other examples, lmk if any other places should be removed