### PR TITLE
Normative version inconsistency for SD-JWT VC in 1.0 final

### DIFF
--- a/1.0/openid-4-verifiable-presentations-1_0.md
+++ b/1.0/openid-4-verifiable-presentations-1_0.md
@@ -1762,7 +1762,7 @@ Implementers should be aware that this specification uses several specifications
 * OpenID Federation 1.0 draft -43 [@!OpenID.Federation]
 * SIOPv2 draft -13 [@!SIOPv2]
 * Selective Disclosure for JWTs (SD-JWT) draft -22 [@!I-D.ietf-oauth-selective-disclosure-jwt]
-* SD-JWT-based Verifiable Credentials (SD-JWT VC) draft -09 [@!I-D.ietf-oauth-sd-jwt-vc]
+* SD-JWT-based Verifiable Credentials (SD-JWT VC) draft -10 [@!I-D.ietf-oauth-sd-jwt-vc]
 * Fully-Specified Algorithms for JOSE and COSE draft -13 [@!I-D.ietf-jose-fully-specified-algorithms]
 
 While breaking changes to the specifications referenced in this specification are not expected, should they occur, OpenID4VP implementations should continue to use the specifically referenced versions above in preference to the final versions, unless updated by a profile or new version of this specification.

--- a/1.0/openid-4-verifiable-presentations-1_0.md
+++ b/1.0/openid-4-verifiable-presentations-1_0.md
@@ -1762,7 +1762,7 @@ Implementers should be aware that this specification uses several specifications
 * OpenID Federation 1.0 draft -43 [@!OpenID.Federation]
 * SIOPv2 draft -13 [@!SIOPv2]
 * Selective Disclosure for JWTs (SD-JWT) draft -22 [@!I-D.ietf-oauth-selective-disclosure-jwt]
-* SD-JWT-based Verifiable Credentials (SD-JWT VC) draft -10 [@!I-D.ietf-oauth-sd-jwt-vc]
+* SD-JWT-based Verifiable Credentials (SD-JWT VC) draft -16 [@!I-D.ietf-oauth-sd-jwt-vc]
 * Fully-Specified Algorithms for JOSE and COSE draft -13 [@!I-D.ietf-jose-fully-specified-algorithms]
 
 While breaking changes to the specifications referenced in this specification are not expected, should they occur, OpenID4VP implementations should continue to use the specifically referenced versions above in preference to the final versions, unless updated by a profile or new version of this specification.
@@ -3211,7 +3211,7 @@ The following outlines a suggested non-normative set of processing steps for SD-
 
 ##### Step 1: SD-JWT VC Processing
 
-- A receiver (holder or verifier) of an SD-JWT VCLD applies the processing rules outlined in Section 4 of [@!I-D.ietf-oauth-sd-jwt-vc], including verifying signatures, validity periods, status information, etc.
+- A receiver (holder or verifier) of an SD-JWT VCLD applies the processing rules outlined in Section 2 of [@!I-D.ietf-oauth-sd-jwt-vc], including verifying signatures, validity periods, status information, etc.
 - If the `vct` value is associated with any SD-JWT VC Type Metadata, schema validation of the entire SD-JWT VCLD is performed, including the nested `ld` claim.
 - Additionally, trust framework rules are applied, such as ensuring the Credential Issuer is authorized to issue SD-JWT VCLDs for the specified `vct` value.
 

--- a/1.1/openid-4-verifiable-presentations-1_1.md
+++ b/1.1/openid-4-verifiable-presentations-1_1.md
@@ -1822,7 +1822,7 @@ Implementers should be aware that this specification uses several specifications
 * OpenID Federation 1.0 draft -43 [@!OpenID.Federation]
 * SIOPv2 draft -13 [@!SIOPv2]
 * Selective Disclosure for JWTs (SD-JWT) draft -22 [@!I-D.ietf-oauth-selective-disclosure-jwt]
-* SD-JWT-based Verifiable Credentials (SD-JWT VC) draft -09 [@!I-D.ietf-oauth-sd-jwt-vc]
+* SD-JWT-based Verifiable Credentials (SD-JWT VC) draft -10 [@!I-D.ietf-oauth-sd-jwt-vc]
 * Fully-Specified Algorithms for JOSE and COSE draft -13 [@!I-D.ietf-jose-fully-specified-algorithms]
 
 While breaking changes to the specifications referenced in this specification are not expected, should they occur, OpenID4VP implementations should continue to use the specifically referenced versions above in preference to the final versions, unless updated by a profile or new version of this specification.

--- a/1.1/openid-4-verifiable-presentations-1_1.md
+++ b/1.1/openid-4-verifiable-presentations-1_1.md
@@ -1822,7 +1822,7 @@ Implementers should be aware that this specification uses several specifications
 * OpenID Federation 1.0 draft -43 [@!OpenID.Federation]
 * SIOPv2 draft -13 [@!SIOPv2]
 * Selective Disclosure for JWTs (SD-JWT) draft -22 [@!I-D.ietf-oauth-selective-disclosure-jwt]
-* SD-JWT-based Verifiable Credentials (SD-JWT VC) draft -10 [@!I-D.ietf-oauth-sd-jwt-vc]
+* SD-JWT-based Verifiable Credentials (SD-JWT VC) draft -16 [@!I-D.ietf-oauth-sd-jwt-vc]
 * Fully-Specified Algorithms for JOSE and COSE draft -13 [@!I-D.ietf-jose-fully-specified-algorithms]
 
 While breaking changes to the specifications referenced in this specification are not expected, should they occur, OpenID4VP implementations should continue to use the specifically referenced versions above in preference to the final versions, unless updated by a profile or new version of this specification.
@@ -3276,7 +3276,7 @@ The following outlines a suggested non-normative set of processing steps for SD-
 
 ##### Step 1: SD-JWT VC Processing
 
-- A receiver (holder or verifier) of an SD-JWT VCLD applies the processing rules outlined in Section 4 of [@!I-D.ietf-oauth-sd-jwt-vc], including verifying signatures, validity periods, status information, etc.
+- A receiver (holder or verifier) of an SD-JWT VCLD applies the processing rules outlined in Section 2 of [@!I-D.ietf-oauth-sd-jwt-vc], including verifying signatures, validity periods, status information, etc.
 - If the `vct` value is associated with any SD-JWT VC Type Metadata, schema validation of the entire SD-JWT VCLD is performed, including the nested `ld` claim.
 - Additionally, trust framework rules are applied, such as ensuring the Credential Issuer is authorized to issue SD-JWT VCLDs for the specified `vct` value.
 


### PR DESCRIPTION
fixes #659 by changing typo in sd-jwt-vc version