### PR TITLE
Add additional text clarifying how to match vct and doctype

### DIFF
--- a/1.1/openid-4-verifiable-presentations-1_1.md
+++ b/1.1/openid-4-verifiable-presentations-1_1.md
@@ -2889,8 +2889,7 @@ The following is an ISO mdoc specific parameter in the `meta` parameter in a Cre
 
 `doctype_value`:
 : REQUIRED. String that specifies an allowed value for the
-doctype of the requested Verifiable Credential. It MUST
-be a valid doctype identifier as defined in [@ISO.18013-5].
+doctype of the requested Verifiable Credential. It MUST be a valid doctype identifier as defined in [@ISO.18013-5]. For a mdoc to satisfy the Credential Query, the value of the `docType` element in the `MobileSecurityObject` structure MUST be equal to the `doctype_value`.
 
 ### Parameter in the Claims Query {#mdocs_claims_query}
 
@@ -3249,11 +3248,13 @@ The following is a non-normative example of `client_metadata` request parameter 
 The following is an SD-JWT VC specific parameter in the `meta` parameter in a Credential Query as defined in (#credential_query).
 
 `vct_values`:
-: REQUIRED. A non-empty array of strings that specifies allowed values for
-the type of the requested Verifiable Credential. All elements in the array MUST
-be valid type identifiers as defined in [@!I-D.ietf-oauth-sd-jwt-vc]. The Wallet
-MAY return Credentials that inherit from any of the specified types, following
-the inheritance logic defined in [@!I-D.ietf-oauth-sd-jwt-vc].
+: REQUIRED. A non-empty array of strings that specifies allowed values for the type of the requested Verifiable Credential. All elements in the array MUST be valid type identifiers as defined in [@!I-D.ietf-oauth-sd-jwt-vc]. To satisfy the Credential Query, a Credential MUST either have or inherit from a type that is included in the `vct_values` array as defined in [@!I-D.ietf-oauth-sd-jwt-vc]. 
+
+A Credential's type can be determined as satifying the Credential Query as follows:
+
+1. Check if the `vct` in the Credential is contained in the `vct_values` array. If it is, the Credential satisfies the Credential Query.
+1. If is is not, check if the Credential has an `extends` claim. If it does repeat this process for the Type metadata  specified by the `extends` value, until either a match is found or the `extends` claim is not present.
+1. If none of the above conditions are met, the Credential's type does not satisfy the Credential Query.
 
 ### Presentation Response
 

--- a/1.1/openid-4-verifiable-presentations-1_1.md
+++ b/1.1/openid-4-verifiable-presentations-1_1.md
@@ -3253,7 +3253,7 @@ The following is an SD-JWT VC specific parameter in the `meta` parameter in a Cr
 A Credential's type can be determined as satifying the Credential Query as follows:
 
 1. Check if the `vct` in the Credential is contained in the `vct_values` array. If it is, the Credential satisfies the Credential Query.
-1. If `vct` in the Credential is not contained in the `vct_values` array, check if the Credential has an `extends` claim. If it does, repeat this process for the Type metadata specified by the `extends` value, until either a match is found or the `extends` claim is not present. If a circular dependency is detected while following `extends` claims, the Credential does not satisfy the Credential Query.
+1. If `vct` in the Credential is not contained in the `vct_values` array, check if the Credential has an `extends` claim. If it does, repeat this process for the Type metadata specified by the `extends` value, until either a match is found or the `extends` claim is not present. If a circular dependency is detected while following the `extends` claims, the Credential does not satisfy the Credential Query.
 1. If none of the above conditions are met, the Credential does not satisfy the Credential Query.
 
 ### Presentation Response

--- a/1.1/openid-4-verifiable-presentations-1_1.md
+++ b/1.1/openid-4-verifiable-presentations-1_1.md
@@ -2889,7 +2889,7 @@ The following is an ISO mdoc specific parameter in the `meta` parameter in a Cre
 
 `doctype_value`:
 : REQUIRED. String that specifies an allowed value for the
-doctype of the requested Verifiable Credential. It MUST be a valid doctype identifier as defined in [@ISO.18013-5]. For a mdoc to satisfy the Credential Query, the value of the `docType` element in the `MobileSecurityObject` structure MUST be equal to the `doctype_value`.
+doctype of the requested Verifiable Credential. It MUST be a valid doctype identifier as defined in [@ISO.18013-5]. For an mdoc to satisfy the Credential Query, the value of the `docType` element in the `MobileSecurityObject` structure MUST be equal to the `doctype_value`.
 
 ### Parameter in the Claims Query {#mdocs_claims_query}
 

--- a/1.1/openid-4-verifiable-presentations-1_1.md
+++ b/1.1/openid-4-verifiable-presentations-1_1.md
@@ -3253,7 +3253,7 @@ The following is an SD-JWT VC specific parameter in the `meta` parameter in a Cr
 A Credential's type can be determined as satifying the Credential Query as follows:
 
 1. Check if the `vct` in the Credential is contained in the `vct_values` array. If it is, the Credential satisfies the Credential Query.
-1. If `vct` in the Credential is not contained in the `vct_values` array, check if the Credential has an `extends` claim. If it does, repeat this process for the Type metadata specified by the `extends` value, until either a match is found or the `extends` claim is not present.
+1. If `vct` in the Credential is not contained in the `vct_values` array, check if the Credential has an `extends` claim. If it does, repeat this process for the Type metadata specified by the `extends` value, until either a match is found or the `extends` claim is not present. If a circular dependency is detected while following `extends` claims, the Credential does not satisfy the Credential Query.
 1. If none of the above conditions are met, the Credential does not satisfy the Credential Query.
 
 ### Presentation Response

--- a/1.1/openid-4-verifiable-presentations-1_1.md
+++ b/1.1/openid-4-verifiable-presentations-1_1.md
@@ -3253,7 +3253,7 @@ The following is an SD-JWT VC specific parameter in the `meta` parameter in a Cr
 A Credential's type can be determined as satifying the Credential Query as follows:
 
 1. Check if the `vct` in the Credential is contained in the `vct_values` array. If it is, the Credential satisfies the Credential Query.
-1. If is is not, check if the Credential has an `extends` claim. If it does repeat this process for the Type metadata  specified by the `extends` value, until either a match is found or the `extends` claim is not present.
+1. If `vct` in the Credential is not contained in the `vct_values` array, check if the Credential has an `extends` claim. If it does, repeat this process for the Type metadata specified by the `extends` value, until either a match is found or the `extends` claim is not present.
 1. If none of the above conditions are met, the Credential's type does not satisfy the Credential Query.
 
 ### Presentation Response

--- a/1.1/openid-4-verifiable-presentations-1_1.md
+++ b/1.1/openid-4-verifiable-presentations-1_1.md
@@ -3250,7 +3250,7 @@ The following is an SD-JWT VC specific parameter in the `meta` parameter in a Cr
 `vct_values`:
 : REQUIRED. A non-empty array of strings that specifies allowed values for the type of the requested Verifiable Credential. All elements in the array MUST be valid type identifiers as defined in [@!I-D.ietf-oauth-sd-jwt-vc]. To satisfy the Credential Query, a Credential MUST either have or inherit from a type that is included in the `vct_values` array as defined in [@!I-D.ietf-oauth-sd-jwt-vc]. 
 
-A Credential's type can be determined as satifying the Credential Query as follows:
+The Wallet MUST determine whether a Credential's type satisfies a Credential Query by following these steps:
 
 1. Check if the `vct` in the Credential is contained in the `vct_values` array. If it is, the Credential satisfies the Credential Query.
 1. If `vct` in the Credential is not contained in the `vct_values` array, check if the Credential has an `extends` claim. If it does, repeat this process for the Type metadata specified by the `extends` value, until either a match is found or the `extends` claim is not present. If a circular dependency is detected while following the `extends` claims, the Credential does not satisfy the Credential Query.

--- a/1.1/openid-4-verifiable-presentations-1_1.md
+++ b/1.1/openid-4-verifiable-presentations-1_1.md
@@ -3250,7 +3250,7 @@ The following is an SD-JWT VC specific parameter in the `meta` parameter in a Cr
 `vct_values`:
 : REQUIRED. A non-empty array of strings that specifies allowed values for the type of the requested Verifiable Credential. All elements in the array MUST be valid type identifiers as defined in [@!I-D.ietf-oauth-sd-jwt-vc]. To satisfy the Credential Query, a Credential MUST either have or inherit from a type that is included in the `vct_values` array as defined in [@!I-D.ietf-oauth-sd-jwt-vc]. 
 
-The Wallet MUST determine whether a Credential's type satisfies a Credential Query by following these steps:
+When a Wallet or Verifier needs to determine whether a Credential's type satisfies a Credential Query, it MUST do so by following these steps:
 
 1. Check if the `vct` in the Credential is contained in the `vct_values` array. If it is, the Credential satisfies the Credential Query.
 1. If the `vct` in the Credential is not contained in the `vct_values` array, check if the Credential has an `extends` claim. If it does, repeat this process for the Type metadata specified by the `extends` value, until either a match is found or the `extends` claim is not present. If a circular dependency is detected while following the `extends` claims, the Credential does not satisfy the Credential Query.

--- a/1.1/openid-4-verifiable-presentations-1_1.md
+++ b/1.1/openid-4-verifiable-presentations-1_1.md
@@ -3253,7 +3253,7 @@ The following is an SD-JWT VC specific parameter in the `meta` parameter in a Cr
 The Wallet MUST determine whether a Credential's type satisfies a Credential Query by following these steps:
 
 1. Check if the `vct` in the Credential is contained in the `vct_values` array. If it is, the Credential satisfies the Credential Query.
-1. If `vct` in the Credential is not contained in the `vct_values` array, check if the Credential has an `extends` claim. If it does, repeat this process for the Type metadata specified by the `extends` value, until either a match is found or the `extends` claim is not present. If a circular dependency is detected while following the `extends` claims, the Credential does not satisfy the Credential Query.
+1. If the `vct` in the Credential is not contained in the `vct_values` array, check if the Credential has an `extends` claim. If it does, repeat this process for the Type metadata specified by the `extends` value, until either a match is found or the `extends` claim is not present. If a circular dependency is detected while following the `extends` claims, the Credential does not satisfy the Credential Query.
 1. If none of the above conditions are met, the Credential does not satisfy the Credential Query.
 
 ### Presentation Response

--- a/1.1/openid-4-verifiable-presentations-1_1.md
+++ b/1.1/openid-4-verifiable-presentations-1_1.md
@@ -3254,7 +3254,7 @@ A Credential's type can be determined as satifying the Credential Query as follo
 
 1. Check if the `vct` in the Credential is contained in the `vct_values` array. If it is, the Credential satisfies the Credential Query.
 1. If `vct` in the Credential is not contained in the `vct_values` array, check if the Credential has an `extends` claim. If it does, repeat this process for the Type metadata specified by the `extends` value, until either a match is found or the `extends` claim is not present.
-1. If none of the above conditions are met, the Credential's type does not satisfy the Credential Query.
+1. If none of the above conditions are met, the Credential does not satisfy the Credential Query.
 
 ### Presentation Response
 

--- a/1.1/openid-4-verifiable-presentations-1_1.md
+++ b/1.1/openid-4-verifiable-presentations-1_1.md
@@ -3250,11 +3250,13 @@ The following is an SD-JWT VC specific parameter in the `meta` parameter in a Cr
 `vct_values`:
 : REQUIRED. A non-empty array of strings that specifies allowed values for the type of the requested Verifiable Credential. All elements in the array MUST be valid type identifiers as defined in [@!I-D.ietf-oauth-sd-jwt-vc]. To satisfy the Credential Query, a Credential MUST be of a type that is included in the `vct_values` array as defined in [@!I-D.ietf-oauth-sd-jwt-vc]. 
 
-When a Wallet or Verifier needs to determine whether a Credential's type satisfies a Credential Query, it MUST do so by evaluating if at least one of the following true:
+When a Wallet or Verifier needs to determine whether a Credential's type satisfies a Credential Query, it RECOMMENDED do so by evaluating if at least one of the following true:
 
 1. The value of the `vct` claim in the Credential is contained in the `vct_values` array.
 1. The `aka_vcts` claim is present and has at least one element that is contained in the `vct_values` array.
 1. There exists out of band information that the received `vct` value is interpreted as a match with at least one element in the `vct_values` array.
+
+Note: A Wallet can infer that a Credential satisfies the `vct_values` parameter via out-of-band mechanisms e.g., type extension, in the absence of an `aka_vcts` claim. However, because standard evaluation by the Verifier relies strictly on matching `vct` or `aka_vcts` values, such presentations could be subject to rejection. To preserve data minimization and avoid presentation failure, Wallets should only use out-of-band type resolution when it is known the Verifier will resolve it in the same way and accept the presentation.
 
 ### Presentation Response
 

--- a/1.1/openid-4-verifiable-presentations-1_1.md
+++ b/1.1/openid-4-verifiable-presentations-1_1.md
@@ -3253,7 +3253,8 @@ The following is an SD-JWT VC specific parameter in the `meta` parameter in a Cr
 When a Wallet or Verifier needs to determine whether a Credential's type satisfies a Credential Query, it MUST do so by evaluating if at least one of the following true:
 
 1. The value of the `vct` claim in the Credential is contained in the `vct_values` array.
-1. The `aka_vcts` claim is present and has at least one element that is contained in the `aka_vcts` array.
+1. The `aka_vcts` claim is present and has at least one element that is contained in the `vct_values` array.
+1. There exists out of band information that the received `vct` value is interpreted as a match with at least one element in the `vct_values` array.
 
 ### Presentation Response
 

--- a/1.1/openid-4-verifiable-presentations-1_1.md
+++ b/1.1/openid-4-verifiable-presentations-1_1.md
@@ -3248,13 +3248,12 @@ The following is a non-normative example of `client_metadata` request parameter 
 The following is an SD-JWT VC specific parameter in the `meta` parameter in a Credential Query as defined in (#credential_query).
 
 `vct_values`:
-: REQUIRED. A non-empty array of strings that specifies allowed values for the type of the requested Verifiable Credential. All elements in the array MUST be valid type identifiers as defined in [@!I-D.ietf-oauth-sd-jwt-vc]. To satisfy the Credential Query, a Credential MUST either have or inherit from a type that is included in the `vct_values` array as defined in [@!I-D.ietf-oauth-sd-jwt-vc]. 
+: REQUIRED. A non-empty array of strings that specifies allowed values for the type of the requested Verifiable Credential. All elements in the array MUST be valid type identifiers as defined in [@!I-D.ietf-oauth-sd-jwt-vc]. To satisfy the Credential Query, a Credential MUST be of a type that is included in the `vct_values` array as defined in [@!I-D.ietf-oauth-sd-jwt-vc]. 
 
-When a Wallet or Verifier needs to determine whether a Credential's type satisfies a Credential Query, it MUST do so by following these steps:
+When a Wallet or Verifier needs to determine whether a Credential's type satisfies a Credential Query, it MUST do so by evaluating if at least one of the following true:
 
-1. Check if the `vct` in the Credential is contained in the `vct_values` array. If it is, the Credential satisfies the Credential Query.
-1. If the `vct` in the Credential is not contained in the `vct_values` array, check if the Credential has an `extends` claim. If it does, repeat this process for the Type metadata specified by the `extends` value, until either a match is found or the `extends` claim is not present. If a circular dependency is detected while following the `extends` claims, the Credential does not satisfy the Credential Query.
-1. If none of the above conditions are met, the Credential does not satisfy the Credential Query.
+1. The value of the `vct` claim in the Credential is contained in the `vct_values` array.
+1. The `aka_vcts` claim is present and has at least one element that is contained in the `aka_vcts` array.
 
 ### Presentation Response
 


### PR DESCRIPTION
Resolves #741 by adding more explicit instructions on what allows a Credential to satisfy `vct_values`, and applies similar explicit text to  `doctype_value`

This makes use of the SD-JWT VC draft 15 which added `aka_vcts` for this purpose 