### PR TITLE
complete the https to openid_federation prefix rename in the invalid_request example

### DIFF
--- a/1.0/openid-4-verifiable-presentations-1_0.md
+++ b/1.0/openid-4-verifiable-presentations-1_0.md
@@ -1471,7 +1471,7 @@ The error response follows the rules as defined in [@!RFC6749], with the followi
 - The request contains both a `dcql_query` parameter and a `scope` parameter referencing a DCQL query.
 - The request uses the `vp_token` Response Type but does not include a `dcql_query` parameter nor a `scope` parameter referencing a DCQL query.
 - The Wallet does not support the Client Identifier Prefix passed in the Authorization Request.
-- The Client Identifier passed in the request did not belong to its Client Identifier Prefix, or requirements of a certain prefix were violated, for example an unsigned request was sent with Client Identifier Prefix `https`.
+- The Client Identifier passed in the request did not belong to its Client Identifier Prefix, or requirements of a certain prefix were violated, for example an unsigned request was sent with Client Identifier Prefix `openid_federation`.
 
 `invalid_client`:
 

--- a/1.1/openid-4-verifiable-presentations-1_1.md
+++ b/1.1/openid-4-verifiable-presentations-1_1.md
@@ -1531,7 +1531,7 @@ The error response follows the rules as defined in [@!RFC6749], with the followi
 - The request contains both a `dcql_query` parameter and a `scope` parameter referencing a DCQL query.
 - The request uses the `vp_token` Response Type but does not include a `dcql_query` parameter nor a `scope` parameter referencing a DCQL query.
 - The Wallet does not support the Client Identifier Prefix passed in the Authorization Request.
-- The Client Identifier passed in the request did not belong to its Client Identifier Prefix, or requirements of a certain prefix were violated, for example an unsigned request was sent with Client Identifier Prefix `https`.
+- The Client Identifier passed in the request did not belong to its Client Identifier Prefix, or requirements of a certain prefix were violated, for example an unsigned request was sent with Client Identifier Prefix `openid_federation`.
 
 `invalid_client`:
 


### PR DESCRIPTION
#401 renamed the `https` Client Identifier Prefix to `openid_federation`, including in the sentence immediately below the prefix list, but this occurrence in the `invalid_request` example was missed. Changed in both 1.0 and 1.1.
