### PR TITLE
Normatively define how an SD-JWT VC is returned in vp_token

### DIFF
--- a/1.0/openid-4-verifiable-presentations-1_0.md
+++ b/1.0/openid-4-verifiable-presentations-1_0.md
@@ -3226,6 +3226,8 @@ the inheritance logic defined in [@!I-D.ietf-oauth-sd-jwt-vc].
 
 ### Presentation Response
 
+Each Presentation is represented as a string containing an SD-JWT or SD-JWT+KB in the compact serialized format defined in Section 4 of [@!I-D.ietf-oauth-selective-disclosure-jwt]. The JWS JSON Serialization defined in Section 8 of [@!I-D.ietf-oauth-selective-disclosure-jwt] MUST NOT be used with the `dc+sd-jwt` Credential Format Identifier.
+
 A non-normative example DCQL query using the SD-JWT VC format is shown in (#dcql_query_example).
 The respective response is shown in (#response_dcql_query).
 
@@ -3639,6 +3641,7 @@ The technology described in this specification was made available from contribut
    * Clarify that `aud` corresponds to `issuer` Wallet Metadata paremeter if Dynamic Discovery is used
    * Clarified that request_uri_method is a case-sensitive string
    * Remove requirements for duplicate claim entries
+   * Clarify `dc+sd-jwt` presentations use the compact serialized SD-JWT format
    
 -final
    

--- a/1.1/openid-4-verifiable-presentations-1_1.md
+++ b/1.1/openid-4-verifiable-presentations-1_1.md
@@ -3290,7 +3290,7 @@ the inheritance logic defined in [@!I-D.ietf-oauth-sd-jwt-vc].
 
 ### Presentation Response
 
-Each Presentation is represented as a string containing an SD-JWT or SD-JWT+KB in the compact serialized format defined in Section 4 of [@!I-D.ietf-oauth-selective-disclosure-jwt]. The JWS JSON Serialization defined in Section 8 of [@!I-D.ietf-oauth-selective-disclosure-jwt] MUST NOT be used.
+Each Presentation is represented as a string containing an SD-JWT or SD-JWT+KB in the compact serialized format defined in Section 4 of [@!I-D.ietf-oauth-selective-disclosure-jwt]. The JWS JSON Serialization defined in Section 8 of [@!I-D.ietf-oauth-selective-disclosure-jwt] MUST NOT be used with the `dc+sd-jwt` Credential Format Identifier.
 
 A non-normative example DCQL query using the SD-JWT VC format is shown in (#dcql_query_example).
 The respective response is shown in (#response_dcql_query).
@@ -3707,4 +3707,4 @@ The technology described in this specification was made available from contribut
    * Clarified that request_uri_method is a case-sensitive string
    * Remove requirements for duplicate claim entries
    * add security considerations on untrusted input
-   * Specify that SD-JWT VC presentations use the compact serialized SD-JWT format and that the JWS JSON Serialization must not be used
+   * Clarify `dc+sd-jwt` presentations use the compact serialized SD-JWT format

--- a/1.1/openid-4-verifiable-presentations-1_1.md
+++ b/1.1/openid-4-verifiable-presentations-1_1.md
@@ -3290,6 +3290,8 @@ the inheritance logic defined in [@!I-D.ietf-oauth-sd-jwt-vc].
 
 ### Presentation Response
 
+Each Presentation is represented as a string containing an SD-JWT or SD-JWT+KB in the compact serialized format defined in Section 4 of [@!I-D.ietf-oauth-selective-disclosure-jwt]. The JWS JSON Serialization defined in Section 8 of [@!I-D.ietf-oauth-selective-disclosure-jwt] MUST NOT be used.
+
 A non-normative example DCQL query using the SD-JWT VC format is shown in (#dcql_query_example).
 The respective response is shown in (#response_dcql_query).
 
@@ -3705,3 +3707,4 @@ The technology described in this specification was made available from contribut
    * Clarified that request_uri_method is a case-sensitive string
    * Remove requirements for duplicate claim entries
    * add security considerations on untrusted input
+   * Specify that SD-JWT VC presentations use the compact serialized SD-JWT format and that the JWS JSON Serialization must not be used


### PR DESCRIPTION
Specify that each SD-JWT VC presentation is a string containing an SD-JWT or SD-JWT+KB in the compact serialized format from Section 4 of the SD-JWT specification, and that the JWS JSON Serialization must not be used, as agreed in the working group discussion today.

closes #780