### PR TITLE
Clarify VC without Holder Binding is returned directly in the VP Token

### DIFF
--- a/1.0/openid-4-verifiable-presentations-1_0.md
+++ b/1.0/openid-4-verifiable-presentations-1_0.md
@@ -2663,7 +2663,7 @@ OpenID for Verifiable Presentations is Credential Format agnostic, i.e., it is d
 
 The following sections define the Credential Format specific parameters and rules for W3C Verifiable Credentials compliant to the [@VC_DATA] specification and for W3C Verifiable Presentations of such Credentials.
 
-If `require_cryptographic_holder_binding` is set to `true` in the Credential Query, the Wallet MUST return a Verifiable Presentation of a Verifiable Credential. Otherwise, a Verifiable Credential without Holder Binding MUST be returned, i.e., the Wallet includes the Verifiable Credential itself directly in the VP Token, without wrapping it in a Verifiable Presentation.
+If `require_cryptographic_holder_binding` is set to `true` in the Credential Query, the Wallet MUST return a Verifiable Presentation of a Verifiable Credential. If set to `false`, a Verifiable Credential without Holder Binding MUST be returned, i.e., the Wallet includes the Verifiable Credential itself directly in the VP Token, without wrapping it in a Verifiable Presentation.
 
 ### Parameters in the `meta` parameter in Credential Query
 

--- a/1.0/openid-4-verifiable-presentations-1_0.md
+++ b/1.0/openid-4-verifiable-presentations-1_0.md
@@ -2663,7 +2663,7 @@ OpenID for Verifiable Presentations is Credential Format agnostic, i.e., it is d
 
 The following sections define the Credential Format specific parameters and rules for W3C Verifiable Credentials compliant to the [@VC_DATA] specification and for W3C Verifiable Presentations of such Credentials.
 
-If `require_cryptographic_holder_binding` is set to `true` in the Credential Query, the Wallet MUST return a Verifiable Presentation of a Verifiable Credential. Otherwise, a Verifiable Credential without Holder Binding MUST be returned.
+If `require_cryptographic_holder_binding` is set to `true` in the Credential Query, the Wallet MUST return a Verifiable Presentation of a Verifiable Credential. Otherwise, a Verifiable Credential without Holder Binding MUST be returned, i.e., the Wallet includes the Verifiable Credential itself directly in the VP Token, without wrapping it in a Verifiable Presentation.
 
 ### Parameters in the `meta` parameter in Credential Query
 
@@ -2768,7 +2768,7 @@ The following is a non-normative example of the contents of this parameter:
 
 ##### Presentation Response
 
-The following requirements apply to the `nonce` and `aud` claims of the Verifiable Presentation:
+When a Verifiable Presentation is returned, the following requirements apply to its `nonce` and `aud` claims:
 
 - the `nonce` claim MUST be the value of `nonce` from the Authorization Request;
 - the `aud` claim MUST be the value of the Client Identifier, except for requests over the DC API where it MUST be the Origin prefixed with `origin:`, as described in (#dc_api_response).
@@ -2822,7 +2822,7 @@ The following is a non-normative example of the contents of this parameter:
 
 ##### Presentation Response
 
-The following requirements apply to the `challenge` and `domain` claims within the `proof` object in the Verifiable Presentation:
+When a Verifiable Presentation is returned, the following requirements apply to the `challenge` and `domain` claims within its `proof` object:
 
 - the `challenge` claim MUST be the value of `nonce` from the Authorization Request;
 - the `domain` claim MUST be the value of the Client Identifier, except for requests over the DC API where it MUST be the Origin prefixed with `origin:`, as described in (#dc_api_response).
@@ -3660,6 +3660,7 @@ The technology described in this specification was made available from contribut
 
 -31
 
+   * Clarify that a W3C Verifiable Credential requested without Cryptographic Holder Binding is returned directly in the VP Token, without a Verifiable Presentation
    * add security considerations on untrusted input
    * Clarify that the Wallet does not follow HTTP redirects
    * Clarify jwks use parameter

--- a/1.1/openid-4-verifiable-presentations-1_1.md
+++ b/1.1/openid-4-verifiable-presentations-1_1.md
@@ -2735,7 +2735,7 @@ OpenID for Verifiable Presentations is Credential Format agnostic, i.e., it is d
 
 The following sections define the Credential Format specific parameters and rules for W3C Verifiable Credentials compliant to the [@VC_DATA] specification and for W3C Verifiable Presentations of such Credentials.
 
-If `require_cryptographic_holder_binding` is set to `true` in the Credential Query, the Wallet MUST return a Verifiable Presentation of a Verifiable Credential. Otherwise, a Verifiable Credential without Holder Binding MUST be returned.
+If `require_cryptographic_holder_binding` is set to `true` in the Credential Query, the Wallet MUST return a Verifiable Presentation of a Verifiable Credential. Otherwise, a Verifiable Credential without Holder Binding MUST be returned, i.e., the Wallet includes the Verifiable Credential itself directly in the VP Token, without wrapping it in a Verifiable Presentation.
 
 ### Parameters in the `meta` parameter in Credential Query
 
@@ -2840,7 +2840,7 @@ The following is a non-normative example of the contents of this parameter:
 
 ##### Presentation Response
 
-The following requirements apply to the `nonce` and `aud` claims of the Verifiable Presentation:
+When a Verifiable Presentation is returned, the following requirements apply to its `nonce` and `aud` claims:
 
 - the `nonce` claim MUST be the value of `nonce` from the Authorization Request;
 - the `aud` claim MUST be the value of the Client Identifier, except for requests over the DC API where it MUST be the Origin prefixed with `origin:`, as described in (#dc_api_response).
@@ -2894,7 +2894,7 @@ The following is a non-normative example of the contents of this parameter:
 
 ##### Presentation Response
 
-The following requirements apply to the `challenge` and `domain` claims within the `proof` object in the Verifiable Presentation:
+When a Verifiable Presentation is returned, the following requirements apply to the `challenge` and `domain` claims within its `proof` object:
 
 - the `challenge` claim MUST be the value of `nonce` from the Authorization Request;
 - the `domain` claim MUST be the value of the Client Identifier, except for requests over the DC API where it MUST be the Origin prefixed with `origin:`, as described in (#dc_api_response).
@@ -3732,6 +3732,7 @@ The technology described in this specification was made available from contribut
 
    -01
 
+   * Clarify that a W3C Verifiable Credential requested without Cryptographic Holder Binding is returned directly in the VP Token, without a Verifiable Presentation
    * Clarify that the Wallet does not follow HTTP redirects
    * Clarify jwks use parameter
    * Clarify nonce entropy requirements

--- a/1.1/openid-4-verifiable-presentations-1_1.md
+++ b/1.1/openid-4-verifiable-presentations-1_1.md
@@ -2735,7 +2735,7 @@ OpenID for Verifiable Presentations is Credential Format agnostic, i.e., it is d
 
 The following sections define the Credential Format specific parameters and rules for W3C Verifiable Credentials compliant to the [@VC_DATA] specification and for W3C Verifiable Presentations of such Credentials.
 
-If `require_cryptographic_holder_binding` is set to `true` in the Credential Query, the Wallet MUST return a Verifiable Presentation of a Verifiable Credential. Otherwise, a Verifiable Credential without Holder Binding MUST be returned, i.e., the Wallet includes the Verifiable Credential itself directly in the VP Token, without wrapping it in a Verifiable Presentation.
+If `require_cryptographic_holder_binding` is set to `true` in the Credential Query, the Wallet MUST return a Verifiable Presentation of a Verifiable Credential. If set to `false`, a Verifiable Credential without Holder Binding MUST be returned, i.e., the Wallet includes the Verifiable Credential itself directly in the VP Token, without wrapping it in a Verifiable Presentation.
 
 ### Parameters in the `meta` parameter in Credential Query
 


### PR DESCRIPTION
When require_cryptographic_holder_binding is false, implementers were unsure whether to return the bare W3C Verifiable Credential or a Verifiable Presentation envelope without a proof. Clarify that the Credential itself goes directly into the VP Token, and scope the nonce/aud and challenge/domain requirements in the jwt_vc_json and ldp_vc Presentation Response sections to the case where a Verifiable Presentation is returned.

Fixes #742